### PR TITLE
Fix broker port mismatch in NS-3 examples

### DIFF
--- a/integration/control/ns3-helics-grid-dnp3-4G.cc
+++ b/integration/control/ns3-helics-grid-dnp3-4G.cc
@@ -281,7 +281,7 @@ main (int argc, char *argv[])
   readMicroGridConfig(helicsConfigFileName, helicsConfigObject);
   readMicroGridConfig(topologyConfigFileName, topologyConfigObject);
 
-  HelicsHelper helicsHelper(6000);
+  HelicsHelper helicsHelper(std::stoi(helicsConfigObject["brokerPort"].asString()));
   std::cout << "Calling Calling Message Federate Constructor" << std::endl;
   helicsHelper.SetupApplicationFederate();
 

--- a/integration/control/ns3-helics-grid-dnp3-5G.cc
+++ b/integration/control/ns3-helics-grid-dnp3-5G.cc
@@ -327,7 +327,7 @@ main (int argc, char *argv[])
   readMicroGridConfig(topologyConfigFileName, topologyConfigObject);
 
   
-  HelicsHelper helicsHelper(6000);
+  HelicsHelper helicsHelper(std::stoi(helicsConfigObject["brokerPort"].asString()));
   std::cout << "Calling Calling Message Federate Constructor" << std::endl; 
   helicsHelper.SetupApplicationFederate();
   std::string fedName = helics_federate->getName();

--- a/integration/control/ns3-helics-grid-dnp3-direct-analog.cc
+++ b/integration/control/ns3-helics-grid-dnp3-direct-analog.cc
@@ -175,7 +175,7 @@ main (int argc, char *argv[])
   readMicroGridConfig(configFileName, configObject);
   readMicroGridConfig(helicsConfigFileName, helicsConfigObject);
 
-  HelicsHelper helicsHelper;
+  HelicsHelper helicsHelper(std::stoi(helicsConfigObject["brokerPort"].asString()));
   std::cout << "Calling Calling Message Federate Constructor" << std::endl;
   helicsHelper.SetupApplicationFederate();
 

--- a/integration/control/ns3-helics-grid-dnp3-direct-binary.cc
+++ b/integration/control/ns3-helics-grid-dnp3-direct-binary.cc
@@ -128,7 +128,7 @@ main (int argc, char *argv[])
   readMicroGridConfig(configFileName, configObject);
   readMicroGridConfig(helicsConfigFileName, helicsConfigObject);
 
-  HelicsHelper helicsHelper;
+  HelicsHelper helicsHelper(std::stoi(helicsConfigObject["brokerPort"].asString()));
   std::cout << "Calling Calling Message Federate Constructor" << std::endl;
   helicsHelper.SetupApplicationFederate();
 

--- a/integration/control/ns3-helics-grid-dnp3.cc
+++ b/integration/control/ns3-helics-grid-dnp3.cc
@@ -178,7 +178,7 @@ main (int argc, char *argv[])
   readMicroGridConfig(helicsConfigFileName, helicsConfigObject);
   readMicroGridConfig(topologyConfigFileName, topologyConfigObject);
 
-  HelicsHelper helicsHelper(6000);
+  HelicsHelper helicsHelper(std::stoi(helicsConfigObject["brokerPort"].asString()));
   std::cout << "Calling Calling Message Federate Constructor" << std::endl;
   helicsHelper.SetupApplicationFederate();
 


### PR DESCRIPTION
## Summary
- use brokerPort from JSON config when creating `HelicsHelper`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6844e06da0a4832f81548163585d97c9