### PR TITLE
Fix duplicate cp in update_workstation.sh

### DIFF
--- a/update_workstation.sh
+++ b/update_workstation.sh
@@ -35,7 +35,6 @@ mkdir ${RD2C}/ns-3-dev/src/dnp3/model
 cp -r RC/code/dnp3/wscript ${RD2C}/ns-3-dev/src/dnp3/ 
 cp -r RC/code/dnp3/model/dnp3-application.h ${RD2C}/ns-3-dev/src/dnp3/model/ 
 cp -r RC/code/dnp3/model/dnp3-application-Docker.cc ${RD2C}/ns-3-dev/src/dnp3/model/dnp3-application.cc 
-cp -r RC/code/dnp3/model/dnp3-application-Docker.cc ${RD2C}/ns-3-dev/src/dnp3/model/dnp3-application.cc 
 cp -r RC/code/dnp3/model/dnp3-simulator-impl.* ${RD2C}/ns-3-dev/src/dnp3/model/ 
 cp -r RC/code/dnp3/model/tcptest* ${RD2C}/ns-3-dev/src/dnp3/model/ 
 cp -r RC/code/dnp3/model/dnp3-mim-* ${RD2C}/ns-3-dev/src/dnp3/model/ 


### PR DESCRIPTION
## Summary
- clean up `update_workstation.sh`
- remove duplicate copy command for `dnp3-application-Docker.cc`

## Testing
- `bash -n update_workstation.sh`

------
https://chatgpt.com/codex/tasks/task_e_6847da20d894832f948180fbdf187bd2