### PR TITLE
Update jsoncpp includes for dnp3 module

### DIFF
--- a/patch/dnp3/wscript
+++ b/patch/dnp3/wscript
@@ -8,6 +8,7 @@ def build(bld):
     module.includes = [
         '.',
         '/usr/local/include/jsoncpp',
+        '/usr/include/jsoncpp',
     ]
 
     module.source = [


### PR DESCRIPTION
## Summary
- reference jsoncpp includes from both `/usr/include` and `/usr/local/include`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6847dba20c24832f99e616fa4407ebaa