### PR TITLE
Set LDFLAGS for ns-3 builds

### DIFF
--- a/RC/code/make.sh
+++ b/RC/code/make.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-LDFLAGS="-ljsoncpp -L$1/include/json/"
+# Use provided LDFLAGS if available, otherwise fall back to the default path
+: "${LDFLAGS:=-ljsoncpp -L$1/include/json/}"
+export LDFLAGS
+echo "Using LDFLAGS=$LDFLAGS"
 #./waf clean
-./waf configure --prefix=$1 --with-helics=$1  --with-zmq=$1 --disable-werror --enable-examples --enable-tests --enable-mpi --build-profile=optimized 
+./waf configure --prefix=$1 --with-helics=$1 --with-zmq=$1 --disable-werror --enable-examples --enable-tests --enable-mpi --build-profile=optimized
 ./waf build
 ./waf install

--- a/build_ns3.sh
+++ b/build_ns3.sh
@@ -54,7 +54,8 @@ cp -r /rd2c/PUSH/NATIG/RC/code/helics/dnp3-application-new* /rd2c/ns-3-dev/contr
 cp -r /rd2c/PUSH/NATIG/RC/code/helics/dnp3-application-new-Docker.cc /rd2c/ns-3-dev/contrib/helics/model/dnp3-application-new.cc
 cp -r /rd2c/PUSH/NATIG/RC/code/helics/dnp3-application-new-Docker.h /rd2c/ns-3-dev/contrib/helics/model/dnp3-application-new.h
 cp -r /rd2c/PUSH/NATIG/RC/code/helics/wscript /rd2c/ns-3-dev/contrib/helics/
-sudo ./make.sh $2
+# Pass linker flags through sudo so that ns-3 builds with the proper libraries
+sudo env "LDFLAGS=$LDFLAGS" ./make.sh $2
 if [ "$1" == "5G" ]; then
     echo "installing 5G"
     cd contrib
@@ -64,6 +65,6 @@ if [ "$1" == "5G" ]; then
     git checkout 5g-lena-v1.2.y
     cd ../../
     cp -r $2/PUSH/NATIG/patch/nr/* contrib/nr/
-    sudo ./make.sh $2
+    sudo env "LDFLAGS=$LDFLAGS" ./make.sh $2
 fi
 mkdir $2/integration/control/physicalDevOutput

--- a/update_workstation.sh
+++ b/update_workstation.sh
@@ -71,7 +71,8 @@ make install
 echo "==== Cleaning up GridLAB-D build files ===="
 make clean
 
-LDFLAGS="-ljsoncpp -L/usr/local/include/jsoncpp/"
+# Export linker flags so ns-3 picks them up during the build
+export LDFLAGS="-ljsoncpp -L/usr/local/include/jsoncpp/"
 cd $RD2C/PUSH/NATIG
 ./build_ns3.sh "$1" ${RD2C}
 


### PR DESCRIPTION
## Summary
- export `LDFLAGS` when running `update_workstation.sh`
- pass `LDFLAGS` through `sudo` in `build_ns3.sh`
- use the environment's `LDFLAGS` inside `RC/code/make.sh`

## Testing
- `bash -n update_workstation.sh`
- `bash -n build_ns3.sh`
- `bash -n RC/code/make.sh`
- `export LDFLAGS="dummy"; bash RC/code/make.sh /tmp 2>&1 | head -n 2`


------
https://chatgpt.com/codex/tasks/task_e_6847dc64d6f0832f838f027e43181696