### PR TITLE
Fix dnp3 build includes

### DIFF
--- a/patch/dnp3/wscript
+++ b/patch/dnp3/wscript
@@ -7,8 +7,8 @@ def build(bld):
     # Ensure jsoncpp headers are found during compilation
     module.includes = [
         '.',
-        '/usr/local/include/jsoncpp',
         '/usr/include/jsoncpp',
+        '/usr/local/include/jsoncpp',
     ]
 
     module.source = [


### PR DESCRIPTION
## Summary
- include `/usr/include/jsoncpp` alongside `/usr/local/include/jsoncpp` for dnp3

## Testing
- `grep -n jsoncpp patch/dnp3/wscript`

------
https://chatgpt.com/codex/tasks/task_e_6847e5a8aa90832f9057f9085ffc3cd4