### PR TITLE
Add HELICS-only build script for Modbus

### DIFF
--- a/develop.sh
+++ b/develop.sh
@@ -4,15 +4,21 @@
 #           DEVELOPMENT WORKFLOW SCRIPT FOR NATIG
 #
 # This script simplifies the workflow to:
-#   1. Patch: Copy your custom files to the right locations.
-#   2. Compile: Rebuild the ns-3 simulator.
-#   3. Run: Execute the simulation.
+#   1. Setup Environment
+#   2. Patch: Copy your custom files to the right locations.
+#   3. Compile: Rebuild the ns-3 simulator.
+#   4. Run: Execute the simulation.
 #
 #################################################################
 
 set -e # Exit immediately if a command exits with a non-zero status.
 
-echo "=== 1. APPLYING CUSTOM PATCHES FROM 'patch/' DIRECTORY ==="
+echo "=== 1. SETTING UP BUILD ENVIRONMENT ==="
+source /rd2c/RC/environmental.sh
+echo "Environment variables set."
+echo ""
+
+echo "=== 2. APPLYING CUSTOM PATCHES FROM 'patch/' DIRECTORY ==="
 
 # Define key directories
 RD2C_DIR="${RD2C:-/rd2c}"
@@ -35,6 +41,7 @@ sync_dir() {
 # Synchronise patched modules with the ns-3 tree
 sync_dir "${PATCH_DIR}/applications"            "${NS3_SRC_DIR}/applications"
 sync_dir "${PATCH_DIR}/dnp3"                     "${NS3_SRC_DIR}/dnp3"
+cp -v "${PATCH_DIR}/dnp3/wscript" "${NS3_SRC_DIR}/dnp3/"
 sync_dir "${PATCH_DIR}/fncs"                     "${NS3_SRC_DIR}/fncs"
 sync_dir "${PATCH_DIR}/internet"                 "${NS3_SRC_DIR}/internet"
 sync_dir "${PATCH_DIR}/lte"                      "${NS3_SRC_DIR}/lte"
@@ -50,7 +57,7 @@ if [ -f "${PATCH_DIR}/make.sh" ]; then
 fi
 
 echo ""
-echo "=== 2. COMPILING NS-3 ==="
+echo "=== 3. COMPILING NS-3 ==="
 
 cd ${NS3_DIR}
 
@@ -67,7 +74,7 @@ if [ $? -ne 0 ]; then
 fi
 
 echo ""
-echo "=== 3. RUNNING SIMULATION ==="
+echo "=== 4. RUNNING SIMULATION ==="
 echo "Compilation successful. Executing run_ns3_only.sh..."
 
 cd ${RD2C_DIR}/integration/control

--- a/patch/dnp3/wscript
+++ b/patch/dnp3/wscript
@@ -1,71 +1,20 @@
-## -*- Mode: python; py-indent-offset: 4; indent-tabs-mode: nil; coding: utf-8; -*-
-
 def build(bld):
+    # Define our custom module. It retains the name 'dnp3'
+    # so that other components that expect this name can find it.
+    # It depends on standard ns-3 modules and HELICS only.
+    module = bld.create_ns3_module('dnp3', ['core', 'network', 'internet', 'point-to-point', 'helics'])
 
-    module = bld.create_ns3_module('dnp3', ['core', 'applications', 'fncs'])
-
-    # Ensure jsoncpp headers are found during compilation
-    module.includes = [
-        '.',
-        '/usr/include/jsoncpp',
-        '/usr/local/include/jsoncpp',
-    ]
-
+    # List ONLY the source files for your custom Modbus applications.
     module.source = [
-        'dnplib/app.cpp',
-        'dnplib/station.cpp',
-        'dnplib/factory.cpp',
-        'dnplib/asdu.cpp',
-        'dnplib/stats.cpp',
-        'dnplib/lpdu.cpp',
-        'dnplib/common.cpp',
-        'dnplib/timer_interface.cpp',
-        'dnplib/datalink.cpp',
-        'dnplib/master.cpp',
-        'dnplib/transmit_interface.cpp',
-        'dnplib/object.cpp',
-        'dnplib/transport.cpp',
-        'dnplib/endpoint.cpp',
-        'dnplib/outstation.cpp',
-        'dnplib/event_interface.cpp',
-        'dnplib/dummy_timer.cpp',
-        'model/dnp3-application.cc',
-        'model/dnp3-simulator-impl.cc',
-        'helper/dnp3-application-helper.cc',
         'model/modbus-master-app.cc',
         'model/modbus-slave-app.cc',
-        'helper/modbus-helper.cc'
-        ]
+        'helper/modbus-helper.cc',
+    ]
 
-    headers = bld(features='ns3header')
-    headers.module = 'dnp3'
-    headers.source = [
-            'model/dnp3-application.h',
-            'model/dnp3-simulator-impl.h',
-            'helper/dnp3-application-helper.h',
-            'model/modbus-master-app.h',
-            'model/modbus-slave-app.h',
-            'helper/modbus-helper.h',
-            'dnplib/app.hpp',
-            'dnplib/station.hpp',
-            'dnplib/factory.hpp',
-            'dnplib/asdu.hpp',
-            'dnplib/stats.hpp',
-            'dnplib/lpdu.hpp',
-            'dnplib/common.hpp',
-            'dnplib/timer_interface.hpp',
-            'dnplib/datalink.hpp',
-            'dnplib/master.hpp',
-            'dnplib/transmit_interface.hpp',
-            'dnplib/object.hpp',
-            'dnplib/transport.hpp',
-            'dnplib/endpoint.hpp',
-            'dnplib/outstation.hpp',
-            'dnplib/event_interface.hpp',
-            'dnplib/dummy_timer.hpp',
-        ]
-    #if bld.env.ENABLE_EXAMPLES:
-    #    bld.recurse('examples')
-
-    # bld.ns3_python_bindings()
+    # Define the headers for your custom applications.
+    module.headers = [
+        'model/modbus-master-app.h',
+        'model/modbus-slave-app.h',
+        'helper/modbus-helper.h',
+    ]
 


### PR DESCRIPTION
## Summary
- simplify `patch/dnp3/wscript` so it builds only the Modbus logic with HELICS
- copy the new `wscript` into ns-3 during development setup
- source environment variables in `develop.sh` before patching ns-3
- name the custom module `dnp3` for compatibility

## Testing
- `bash -n develop.sh`
- `python3 -m py_compile patch/dnp3/wscript`


------
https://chatgpt.com/codex/tasks/task_e_68487b3a8958832f9aef0a10e55b4d01