### PR TITLE
Fix helics deps and complete dnp3 build script

### DIFF
--- a/patch/dnp3/wscript
+++ b/patch/dnp3/wscript
@@ -18,3 +18,9 @@ def build(bld):
         'helper/modbus-helper.h',
     ]
 
+    # Build example programs when enabled
+    if bld.env.ENABLE_EXAMPLES:
+        bld.recurse('examples')
+
+    # Explicitly return the module so that waf knows the build step
+    return module

--- a/patch/helics-backup/wscript
+++ b/patch/helics-backup/wscript
@@ -131,7 +131,10 @@ def build(bld):
     if 'helics' in bld.env['MODULES_NOT_BUILT']:
         return
 
-    module = bld.create_ns3_module('helics', ['core', 'internet','dnp3'])
+    # The HELICS module only depends on the "core" and "internet" modules.
+    # Removing the dnp3 dependency avoids a cyclic build relation with the
+    # customised DNP3 module provided in this repository.
+    module = bld.create_ns3_module('helics', ['core', 'internet'])
     module.source = [
         'model/helics.cc',
         'model/helics-application.cc',


### PR DESCRIPTION
## Summary
- remove dnp3 dependency from helics backup module
- finish the dnp3 wscript with examples and module return

## Testing
- `./develop.sh` *(fails: /rd2c/RC/environmental.sh: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68488c1e9870832f818c59f5599eb62d