### PR TITLE
Remove fncs application from patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ Expected result: logs from HELICS, GridLAB-D, and ns-3 appear; the simulation fi
 3. **Patch, compile and run** using the helper script from the repo root:
    `bash develop.sh`
    The script copies files from the repository's `patch/` folder into `/rd2c/ns-3-dev`, runs `make.sh` to configure and build ns-3, then launches the simulation.
+   
+   *Note: older versions of the patches included an unused `fncs-application` which required `fncs.hpp`. The patch files now omit this code. If you see build errors mentioning `fncs-application.cc`, make sure your `ns-3` source has the updated `patch/applications/wscript`.*
 
 ---
 

--- a/patch/applications/wscript
+++ b/patch/applications/wscript
@@ -22,7 +22,6 @@ def build(bld):
         'model/three-gpp-http-server.cc',
         'model/three-gpp-http-header.cc',
         'model/three-gpp-http-variables.cc',
-        'model/fncs-application.cc', 
         'helper/bulk-send-helper.cc',
         'helper/on-off-helper.cc',
         'helper/packet-sink-helper.cc',
@@ -32,8 +31,6 @@ def build(bld):
         'helper/three-gpp-http-helper.cc',
         ]
 
-    if bld.env['FNCS'] and bld.env['CZMQ'] and bld.env['ZMQ']:
-        module.use.extend(['FNCS', 'CZMQ', 'ZMQ'])
 
     applications_test = bld.create_ns3_module_test_library('applications')
     applications_test.source = [
@@ -65,7 +62,6 @@ def build(bld):
         'model/udp-echo-server.h',
         'model/mim-client.h',
         'model/mim-server.h',
-        'model/fncs-application.h',
         'model/application-packet-probe.h',
         'model/three-gpp-http-client.h',
         'model/three-gpp-http-server.h',


### PR DESCRIPTION
## Summary
- drop stale fncs application build directives
- document the change so users with old clones can update

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68496a5be518832fae0f900fde5e89b9