### PR TITLE
Fix FNCS header path

### DIFF
--- a/RC/code/dnp3/model/dnp3-simulator-impl.cc
+++ b/RC/code/dnp3/model/dnp3-simulator-impl.cc
@@ -38,7 +38,7 @@
 #include <vector>
 
 #ifdef FNCS
-#include </rd2c/include/fncs.hpp>
+#include <fncs.hpp>
 #include <exception>
 typedef std::vector<std::pair<std::string,std::string> > match_list_t;
 #endif

--- a/patch/applications/model/fncs-application.cc
+++ b/patch/applications/model/fncs-application.cc
@@ -37,9 +37,10 @@ using namespace std;
 #include "fncs-application.h"
 #include "ns3/random-variable-stream.h"
 
-//#ifdef FNCS
-#include </rd2c/include/fncs.hpp>
-//#endif
+// The FNCS header should be located via the build system include paths.
+// Use a generic include rather than an absolute one so the code works
+// regardless of where FNCS is installed.
+#include <fncs.hpp>
 
 #include <algorithm>
 #include <sstream>

--- a/patch/modbus/model/dnp3-simulator-impl.cc
+++ b/patch/modbus/model/dnp3-simulator-impl.cc
@@ -38,7 +38,7 @@
 #include <vector>
 
 #ifdef FNCS
-#include </rd2c/include/fncs.hpp>
+#include <fncs.hpp>
 #include <exception>
 typedef std::vector<std::pair<std::string,std::string> > match_list_t;
 #endif


### PR DESCRIPTION
## Summary
- fix incorrect absolute path to `fncs.hpp`

## Testing
- `shellcheck develop.sh`

------
https://chatgpt.com/codex/tasks/task_e_684975369dfc832f98fe8514eb5943d4