### PR TITLE
Disable FNCS when building ns-3

### DIFF
--- a/RC/make.sh
+++ b/RC/make.sh
@@ -154,7 +154,7 @@ make
 make install
 cd ${RD2C}/gridlab-d
 autoreconf -if
-./configure --prefix=${RD2C} --with-xerces=${RD2C} --with-helics=${RD2C} --with-fncs=${RD2C} --enable-silent-rules 'CFLAGS=-g -O2 -w' 'CXXFLAGS=-g -O2 -w -std=c++14' 'LDFLAGS=-g -O2 -w'
+./configure --prefix=${RD2C} --with-xerces=${RD2C} --with-helics=${RD2C} --disable-fncs --enable-silent-rules 'CFLAGS=-g -O2 -w' 'CXXFLAGS=-g -O2 -w -std=c++14' 'LDFLAGS=-g -O2 -w'
 #./configure --with-helics=/usr/local --prefix=$GLD_INSTALL --enable-silent-rules 'CFLAGS=-g -O2 -w' 'CXXFLAGS=-g -O2 -w -std=c++14' 'LDFLAGS=-g -O2 -w' \
 make
 make install

--- a/develop.sh
+++ b/develop.sh
@@ -54,7 +54,7 @@ echo "Cleaning previous build..."
 
 # THIS IS THE FINAL FIX: Pass CXXFLAGS directly to configure
 echo "Configuring new build..."
-CXXFLAGS="-I/usr/local/include" ./waf configure --enable-examples --enable-tests --with-helics=/usr/local
+CXXFLAGS="-I/usr/local/include" ./waf configure --enable-examples --enable-tests --with-helics=/usr/local --disable-fncs
 
 echo "Building ns-3..."
 ./waf

--- a/patch/make.sh
+++ b/patch/make.sh
@@ -2,6 +2,6 @@
 
 LDFLAGS="-ljsoncpp -L/usr/local/include/json/"
 #./waf clean
-./waf configure --with-helics=/usr/local --with-fncs=/rd2c --with-czmq=/rd2c --with-zmq=/rd2c --disable-werror --enable-examples --enable-tests --enable-mpi 
+./waf configure --with-helics=/usr/local --disable-fncs --with-czmq=/rd2c --with-zmq=/rd2c --disable-werror --enable-examples --enable-tests --enable-mpi
 ./waf build
 ./waf install


### PR DESCRIPTION
## Summary
- disable fncs in develop.sh ns-3 build
- disable fncs in the patch/make.sh configuration
- disable fncs for RC/make.sh GridLAB-D build

## Testing
- `bash -n develop.sh`
- `bash make.sh` in `patch/` (fails: `./waf: No such file or directory`)
- `bash make.sh` in `RC/` (interrupted download)
- `bash develop.sh` (fails: cannot stat `/rd2c/patch/...`)


------
https://chatgpt.com/codex/tasks/task_e_68498b377724832f8135aa356f5fa6fa