### PR TITLE
Conditionally include fncs.hpp

### DIFF
--- a/patch/modbus/model/dnp3-application.cc
+++ b/patch/modbus/model/dnp3-application.cc
@@ -60,7 +60,9 @@ using namespace std;
 #include "ns3/object.hpp"
 #include "ns3/asdu.hpp"
 //#include "ns3/global-variables.h"
+#ifdef FNCS
 #include "fncs.hpp"
+#endif
 #include "ns3/seq-ts-header.h"
 #include <cstdlib>
 #include "ns3/helics.h"


### PR DESCRIPTION
## Summary
- protect `fncs.hpp` include in `dnp3-application.cc`

## Testing
- `g++ -c patch/modbus/model/dnp3-application.cc -I/tmp/include -I/usr/include/ns3 -I/usr/include/jsoncpp -std=c++14 -DFNCS -o /tmp/dnp3_with.o` *(fails: ns3/system-thread.h: No such file or directory)*
- `g++ -c patch/modbus/model/dnp3-application.cc -I/tmp/include -I/usr/include/ns3 -I/usr/include/jsoncpp -std=c++14 -o /tmp/dnp3_without.o` *(fails: ns3/system-thread.h: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_684990c21734832f93e02772930cf833