### PR TITLE
Fix modbus wscript

### DIFF
--- a/patch/modbus/wscript
+++ b/patch/modbus/wscript
@@ -1,24 +1,72 @@
-def build(bld):
-    # Define our new, clean 'modbus' module. It depends on the core
-    # ns-3 libraries as well as the custom HELICS contrib module.
-    module = bld.create_ns3_module('modbus',
-                                   ['core', 'network', 'internet',
-                                    'point-to-point', 'helics'])
+## -*- Mode: python; py-indent-offset: 4; indent-tabs-mode: nil; coding: utf-8; -*-
 
-    # Source files for the Modbus applications.
+def build(bld):
+    module = bld.create_ns3_module('modbus', ['core', 'network', 'internet', 'point-to-point', 'helics'])
+
     module.source = [
+        'dnplib/app.cpp',
+        'dnplib/asdu.cpp',
+        'dnplib/common.cpp',
+        'dnplib/datalink.cpp',
+        'dnplib/dummy_timer.cpp',
+        'dnplib/endpoint.cpp',
+        'dnplib/event_interface.cpp',
+        'dnplib/factory.cpp',
+        'dnplib/lpdu.cpp',
+        'dnplib/master.cpp',
+        'dnplib/object.cpp',
+        'dnplib/outstation.cpp',
+        'dnplib/security.cpp',
+        'dnplib/station.cpp',
+        'dnplib/stats.cpp',
+        'dnplib/timer_interface.cpp',
+        'dnplib/transmit_interface.cpp',
+        'dnplib/transport.cpp',
+        'dnplib/version.cpp',
+        'model/dnp3-application.cc',
+        'model/dnp3-mim-application.cc',
+        'model/dnp3-simulator-impl.cc',
         'model/modbus-master-app.cc',
         'model/modbus-slave-app.cc',
+        'model/tcptest-application.cc',
+        'helper/dnp3-application-helper.cc',
+        'helper/dnp3-mim-application-helper.cc',
         'helper/modbus-helper.cc',
-    ]
+        ]
 
-    # Header files that other modules can include.
     headers = bld(features='ns3header')
     headers.module = 'modbus'
     headers.source = [
+        'dnplib/app.hpp',
+        'dnplib/asdu.hpp',
+        'dnplib/common.hpp',
+        'dnplib/datalink.hpp',
+        'dnplib/dummy_timer.hpp',
+        'dnplib/endpoint.hpp',
+        'dnplib/event_interface.hpp',
+        'dnplib/factory.hpp',
+        'dnplib/lpdu.hpp',
+        'dnplib/master.hpp',
+        'dnplib/object.hpp',
+        'dnplib/outstation.hpp',
+        'dnplib/security.hpp',
+        'dnplib/station.hpp',
+        'dnplib/stats.hpp',
+        'dnplib/timer_interface.hpp',
+        'dnplib/transmit_interface.hpp',
+        'dnplib/transport.hpp',
+        'helper/dnp3-application-helper.h',
+        'helper/dnp3-mim-application-helper.h',
+        'helper/modbus-helper.h',
+        'model/dnp3-application.h',
+        'model/dnp3-mim-application.h',
+        'model/dnp3-simulator-impl.h',
         'model/modbus-master-app.h',
         'model/modbus-slave-app.h',
-        'helper/modbus-helper.h',
-    ]
+        'model/tcptest-application.h',
+        ]
 
+    #if bld.env.ENABLE_EXAMPLES:
+    #    bld.recurse('examples')
 
+    # bld.ns3_python_bindings()


### PR DESCRIPTION
## Summary
- rebuild `patch/modbus/wscript` to include all sources and headers
- ensure dependencies include `core`, `network`, `internet`, `point-to-point`, and `helics`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6849b463b740832fa6211e05ab4dc737