### PR TITLE
Include HELICS setup in develop script

### DIFF
--- a/develop.sh
+++ b/develop.sh
@@ -23,6 +23,10 @@ NS3_SRC_DIR="${RD2C_DIR}/ns-3-dev/src"
 PATCH_DIR="${RD2C_DIR}/patch"
 MODBUS_MODULE_DIR="${NS3_SRC_DIR}/modbus"
 OLD_DNP3_DIR="${NS3_SRC_DIR}/dnp3"
+# Set up HELICS module
+echo "Setting up HELICS module..."
+bash "${RD2C_DIR}/PUSH/NATIG/build_helics.sh"
+
 
 echo "=== 2. CREATING CLEAN 'modbus' MODULE STRUCTURE ==="
 # Remove any legacy 'dnp3' module to avoid build conflicts


### PR DESCRIPTION
## Summary
- run `build_helics.sh` inside `develop.sh`
- document the new step with a console message

## Testing
- `bash develop.sh` *(fails: `/rd2c/ns-3-dev/contrib/` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849bdada370832f9c2c43e6f99e3091