### PR TITLE
Apply HELICS patch from repo

### DIFF
--- a/build_helics.sh
+++ b/build_helics.sh
@@ -8,5 +8,6 @@ cp -r /rd2c/PUSH/NATIG/RC/code/helics/dnp3-application-helper-new.* /rd2c/ns-3-d
 cp -r /rd2c/PUSH/NATIG/RC/code/helics/dnp3-application-new* /rd2c/ns-3-dev/contrib/helics/model/
 cp -r /rd2c/ns-3-dev/contrib/helics/model/dnp3-application-new-Docker.h /rd2c/ns-3-dev/contrib/helics/model/dnp3-application-new.h
 cp -r /rd2c/ns-3-dev/contrib/helics/model/dnp3-application-new-Docker.cc /rd2c/ns-3-dev/contrib/helics/model/dnp3-application-new.cc
-cp -r /rd2c/PUSH/NATIG/RC/code/helics/wscript /rd2c/ns-3-dev/contrib/helics/
+cp -r /rd2c/patch/helics-backup/wscript /rd2c/ns-3-dev/contrib/helics/
+echo "Applied HELICS wscript patch"
 cp -r /rd2c/PUSH/NATIG/RC/code/helics/helics-simulator-impl.cc /rd2c/ns-3-dev/contrib/helics/model/

--- a/develop.sh
+++ b/develop.sh
@@ -25,7 +25,7 @@ MODBUS_MODULE_DIR="${NS3_SRC_DIR}/modbus"
 OLD_DNP3_DIR="${NS3_SRC_DIR}/dnp3"
 # Set up HELICS module
 echo "Setting up HELICS module..."
-bash "${RD2C_DIR}/PUSH/NATIG/build_helics.sh"
+bash "${RD2C_DIR}/NATIG/build_helics.sh"
 
 
 echo "=== 2. CREATING CLEAN 'modbus' MODULE STRUCTURE ==="


### PR DESCRIPTION
## Summary
- copy the patched HELICS wscript from `/rd2c/patch`
- invoke `build_helics.sh` from the repo directory

## Testing
- `bash develop.sh` *(fails: /rd2c/NATIG/build_helics.sh: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6849c0628af0832f87a11e918a7c9032