### PR TITLE
Fix HELICS wscript copy path

### DIFF
--- a/build_helics.sh
+++ b/build_helics.sh
@@ -8,6 +8,6 @@ cp -r /rd2c/PUSH/NATIG/RC/code/helics/dnp3-application-helper-new.* /rd2c/ns-3-d
 cp -r /rd2c/PUSH/NATIG/RC/code/helics/dnp3-application-new* /rd2c/ns-3-dev/contrib/helics/model/
 cp -r /rd2c/ns-3-dev/contrib/helics/model/dnp3-application-new-Docker.h /rd2c/ns-3-dev/contrib/helics/model/dnp3-application-new.h
 cp -r /rd2c/ns-3-dev/contrib/helics/model/dnp3-application-new-Docker.cc /rd2c/ns-3-dev/contrib/helics/model/dnp3-application-new.cc
-cp -r /rd2c/patch/helics-backup/wscript /rd2c/ns-3-dev/contrib/helics/
+cp -r /rd2c/PUSH/NATIG/RC/code/helics/wscript /rd2c/ns-3-dev/contrib/helics/
 echo "Applied HELICS wscript patch"
 cp -r /rd2c/PUSH/NATIG/RC/code/helics/helics-simulator-impl.cc /rd2c/ns-3-dev/contrib/helics/model/


### PR DESCRIPTION
## Summary
- update HELICS wscript copy path in `build_helics.sh`

## Testing
- `bash develop.sh` *(fails: `/rd2c/build_helics.sh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849cbad3898832f988b7c409e5b58f7