### PR TITLE
Add NATIG_SRC env and update docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Codex Agent Instructions
+
+When modifying any `*.sh` script within this repository, run `shellcheck` on the modified files and address warnings where possible.
+
+When modifying Markdown files (`*.md`), run `markdownlint` on the changed files.
+
+Always run these checks before committing your changes.

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -57,7 +57,7 @@ NOTE: to change the helics broker's port the gridlabd\_config.json needs to be u
 
 __3G star__: this is a directly connected network that has the control center at the center of the topology and the rest of the nodes are connected in a star pattern
 
-1. To enable this topology, open the grid.json either in /rd2c/PUSH/NATIG/RC/code/<exampleTag>-conf-<modelID> when using the conf input or in the /rd2c/integration/control/config folder when using the noconf input (see section __Commands to run the examples__ for more details about conf vs noconf).
+1. To enable this topology, open the grid.json either in ${NATIG_SRC}/RC/code/<exampleTag>-conf-<modelID> when using the conf input or in the /rd2c/integration/control/config folder when using the noconf input (see section __Commands to run the examples__ for more details about conf vs noconf).
 2. In section "Simulation" change UseDynTop to 0. When running the 3G example it will default the setup to a star topology
 
 ```
@@ -77,7 +77,7 @@ __3G star__: this is a directly connected network that has the control center at
 
 __3G ring__: This is directly connected network that has middle nodes connected using a ring pattern. Then the microgrid ns3 nodes and the control center ns3 node are connected to the individual middle node. 
 
-1. To enable this topology, open the grid.json either in /rd2c/PUSH/NATIG/RC/code/<exampleTag>-conf-<modelID> when using the conf input or in the /rd2c/integration/control/config folder when using the noconf input (see section __Commands to run the examples__ for more details about conf vs noconf).
+1. To enable this topology, open the grid.json either in ${NATIG_SRC}/RC/code/<exampleTag>-conf-<modelID> when using the conf input or in the /rd2c/integration/control/config folder when using the noconf input (see section __Commands to run the examples__ for more details about conf vs noconf).
 2. In section "Simulation" change UseDynTop to 1 as seen in the following output:
 ```
      "Simulation": [
@@ -169,7 +169,7 @@ __3G ring__: This is directly connected network that has middle nodes connected 
 
 __3G mesh__: this is a directly connected network that has middles connected in a mesh pattern. Then the microgrid ns3 nodes and the control center ns3 node are connected to the individual middle node. 
 
-1. To enable this topology, open the grid.json either in /rd2c/PUSH/NATIG/RC/code/<exampleTag>-conf-<modelID> when using the conf input or in the /rd2c/integration/control/config folder when using the noconf input (see section __Commands to run the examples__ for more details about conf vs noconf).
+1. To enable this topology, open the grid.json either in ${NATIG_SRC}/RC/code/<exampleTag>-conf-<modelID> when using the conf input or in the /rd2c/integration/control/config folder when using the noconf input (see section __Commands to run the examples__ for more details about conf vs noconf).
 2. In section "Simulation" change UseDynTop to 1 as seen in the following output:
 ```
      "Simulation": [
@@ -269,7 +269,7 @@ __3G mesh__: this is a directly connected network that has middles connected in 
 
 __4G and 5G topology__: currently the topology type of these two communication networks are statically set in the code. The Microgrid NS3 nodes are connected to the middle nodes using an all to all mesh. Then each middle nodes are connected to an individual User Equipment node using a direct connection. Each User Equipment can communicate to any Relay Antenna (GnB/EnB) nodes. Once the signal is past the cellular network part of the network, the signal is sent through a single connection link that connects the control center to the rest of the network. 
 
-1. To configure some of the elements of the 4G or 5G examples, open the topology.json either in /rd2c/PUSH/NATIG/RC/code/<exampleTag>-conf-<modelID> when using the conf input or in the /rd2c/integration/control/config folder when using the noconf input (see section __Commands to run the examples__ for more details about conf vs noconf).
+1. To configure some of the elements of the 4G or 5G examples, open the topology.json either in ${NATIG_SRC}/RC/code/<exampleTag>-conf-<modelID> when using the conf input or in the /rd2c/integration/control/config folder when using the noconf input (see section __Commands to run the examples__ for more details about conf vs noconf).
 2. The channel section. The values in that section are used accross all three available example (3G|4G|5G)
     1. __P2PDelay__: No longer used
     2. __CSMADelay__: Used to add some delay to the CSMA connections
@@ -367,14 +367,14 @@ __4G and 5G topology__: currently the topology type of these two communication n
 The following steps are assuming that the examples are run on docker:
 
 1. ` cd /rd2c/integration/control `: this command will bring you where the main code and configurations for the run will be located
-2. Running the examples out of the box. These commands are useful when you do not want to make any changes to the configurations or if you just pulled an updated version of the setup and want to make sure that the configurations files bring in any new input. The ` conf ` input will trigger the code to overwrite the configuration files in /rd2c/integration/control/config/ and the glm files in /rd2c/integration/control with the files found in /rd2c/PUSH/NATIG/RC/code/<exampleTag>-conf-<modelID> folders. For example, if running the 3G example with the IEEE 123 bus model, the configuration files and the glm files will be taken from /rd2c/PUSH/NATIG/RC/code/3G-conf-123/
+2. Running the examples out of the box. These commands are useful when you do not want to make any changes to the configurations or if you just pulled an updated version of the setup and want to make sure that the configurations files bring in any new input. The ` conf ` input will trigger the code to overwrite the configuration files in /rd2c/integration/control/config/ and the glm files in /rd2c/integration/control with the files found in ${NATIG_SRC}/RC/code/<exampleTag>-conf-<modelID> folders. For example, if running the 3G example with the IEEE 123 bus model, the configuration files and the glm files will be taken from ${NATIG_SRC}/RC/code/3G-conf-123/
     1. 3G with 123: ` sudo bash run.sh /rd2c/  3G "" 123 conf `
     2. 3G with 9500: ` sudo bash run.sh /rd2c/  3G "" 9500 conf `
     3. 4G with 123: ` sudo bash run.sh /rd2c/  4G "" 123 conf `
     4. 4G with 9500: ` sudo bash run.sh /rd2c/  4G "" 9500 conf `
     5. 5G with 123: ` sudo bash run.sh /rd2c/  5G "" 123 conf `
     6. 5G with 9500: ` sudo bash run.sh /rd2c/  5G "" 9500 conf `
-3. Running the examples with local changes to the config json files and glm files. Using the noconf input it will trigger the code to read the configuration files direct from /rd2c/integration/control/config and the glm files directly from /rd2c/integration/control/ without overwritting them with the files found in /rd2c/PUSH/NATIG/RC/code/<exampleTag>-conf-<modelID>. We recommand at least to do one run of the example with a conf input and then doing noconf changes once you have an updated version of the config file. 
+3. Running the examples with local changes to the config json files and glm files. Using the noconf input it will trigger the code to read the configuration files direct from /rd2c/integration/control/config and the glm files directly from /rd2c/integration/control/ without overwritting them with the files found in ${NATIG_SRC}/RC/code/<exampleTag>-conf-<modelID>. We recommand at least to do one run of the example with a conf input and then doing noconf changes once you have an updated version of the config file. 
     1. 3G with 123: ` sudo bash run.sh /rd2c/  3G "" 123 noconf `
     2. 3G with 9500: ` sudo bash run.sh /rd2c/  3G "" 9500 noconf `
     3. 4G with 123: ` sudo bash run.sh /rd2c/  4G "" 123 noconf `

--- a/RC/code/pythonFederate/tutorial.sh
+++ b/RC/code/pythonFederate/tutorial.sh
@@ -3,6 +3,7 @@
 
 # ==== set root and output
 export RD2C=$1
+NATIG_SRC="${NATIG_SRC:-${RD2C}/PUSH/NATIG}"
 export FNCS_INSTALL=${RD2C}
 export PATH=$PATH:${FNCS_INSTALL}/bin
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${FNCS_INSTALL}/lib
@@ -35,15 +36,15 @@ fi
 #Copying the points file to the config file
 if [[ "$5" == "conf" ]]
 then
-cp ../../PUSH/NATIG/RC/code/points-${4}/* config/
+cp ${NATIG_SRC}/RC/code/points-${4}/* config/
 fi
 
 if [[ "$2" == "4G" ]]
 then
 if [[ "$5" == "conf" ]]
 then
-    cp -r ../../PUSH/NATIG/RC/code/4G-conf-${4}/*.json config/
-    cp -r ../../PUSH/NATIG/RC/code/4G-conf-${4}/*.glm .
+    cp -r ${NATIG_SRC}/RC/code/4G-conf-${4}/*.json config/
+    cp -r ${NATIG_SRC}/RC/code/4G-conf-${4}/*.glm .
 fi
 modelName="ns3-helics-grid-dnp3-4G"
 fi
@@ -51,8 +52,8 @@ if [[ "$2" == "5G" ]]
 then
 if [[ "$5" == "conf" ]]
 then
-    cp -r ../../PUSH/NATIG/RC/code/5G-conf-${4}/*.json config/
-    cp -r ../../PUSH/NATIG/RC/code/5G-conf-${4}/*.glm .
+    cp -r ${NATIG_SRC}/RC/code/5G-conf-${4}/*.json config/
+    cp -r ${NATIG_SRC}/RC/code/5G-conf-${4}/*.glm .
 fi
 modelName="ns3-helics-grid-dnp3-5G"
 fi
@@ -60,8 +61,8 @@ if [[ "$2" == "3G" ]]
 then
 if [[ "$5" == "conf" ]]
 then
-    cp -r ../../PUSH/NATIG/RC/code/3G-conf-${4}/*.json config/
-    cp -r ../../PUSH/NATIG/RC/code/3G-conf-${4}/*.glm .
+    cp -r ${NATIG_SRC}/RC/code/3G-conf-${4}/*.json config/
+    cp -r ${NATIG_SRC}/RC/code/3G-conf-${4}/*.glm .
 fi
 modelName="ns3-helics-grid-dnp3"
 fi

--- a/RC/code/run.sh
+++ b/RC/code/run.sh
@@ -3,6 +3,7 @@
 #SBATCH --time=64:15:00
 # ==== set root and output
 export RD2C=$1
+NATIG_SRC="${NATIG_SRC:-${RD2C}/PUSH/NATIG}"
 export FNCS_INSTALL=${RD2C}
 export PATH=$PATH:${FNCS_INSTALL}/bin
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${FNCS_INSTALL}/lib
@@ -39,15 +40,15 @@ fi
 
 if [[ "$5" == "conf" ]]
 then
-cp ../../PUSH/NATIG/RC/code/points-${4}/* config/
+cp ${NATIG_SRC}/RC/code/points-${4}/* config/
 fi
 
 if [[ "$2" == "4G" ]]
 then
 if [[ "$5" == "conf" ]]
 then
-    cp -r ../../PUSH/NATIG/RC/code/4G-conf-${4}/*.json config/
-    cp -r ../../PUSH/NATIG/RC/code/4G-conf-${4}/*.glm .
+    cp -r ${NATIG_SRC}/RC/code/4G-conf-${4}/*.json config/
+    cp -r ${NATIG_SRC}/RC/code/4G-conf-${4}/*.glm .
 fi
 modelName="ns3-helics-grid-dnp3-4G"
 fi
@@ -55,8 +56,8 @@ if [[ "$2" == "5G" ]]
 then
 if [[ "$5" == "conf" ]]
 then
-    cp -r ../../PUSH/NATIG/RC/code/5G-conf-${4}/*.json config/
-    cp -r ../../PUSH/NATIG/RC/code/5G-conf-${4}/*.glm .
+    cp -r ${NATIG_SRC}/RC/code/5G-conf-${4}/*.json config/
+    cp -r ${NATIG_SRC}/RC/code/5G-conf-${4}/*.glm .
 fi
 modelName="ns3-helics-grid-dnp3-5G"
 fi
@@ -64,8 +65,8 @@ if [[ "$2" == "3G" ]]
 then
 if [[ "$5" == "conf" ]]
 then
-    cp -r ../../PUSH/NATIG/RC/code/3G-conf-${4}/*.json config/
-    cp -r ../../PUSH/NATIG/RC/code/3G-conf-${4}/*.glm .
+    cp -r ${NATIG_SRC}/RC/code/3G-conf-${4}/*.json config/
+    cp -r ${NATIG_SRC}/RC/code/3G-conf-${4}/*.glm .
 fi
 modelName="ns3-helics-grid-dnp3"
 fi

--- a/RC/make.sh
+++ b/RC/make.sh
@@ -5,6 +5,7 @@
 #module load gcc/8.4.0
 
 export RD2C=${PWD}
+NATIG_SRC="${NATIG_SRC:-${NATIG_SRC}}"
 export FNCS_INSTALL=${RD2C}
 export GLD_INSTALL=${RD2C}
 export GLPATH=/rd2c/share/gridlabd/:/rd2c/lib/gridlabd/
@@ -188,62 +189,62 @@ git clone https://github.com/nsnam/ns-3-dev-git.git
 mv ns-3-dev-git ns-3-dev
 cd ns-3-dev
 git checkout ns-3.35
-cd ${RD2C}/PUSH/NATIG
+cd ${NATIG_SRC}
 cd ${RD2C}/ns-3-dev/contrib/
 rm -rf helics
 git clone --depth 1 --branch HELICS-v2.x-waf https://github.com/GMLC-TDC/helics-ns3.git; mv helics-ns3 helics
-cp -r ${RD2C}/PUSH/NATIG/RC/code/helics/helics-helper* ${RD2C}/ns-3-dev/contrib/helics/helper/
-cp -r ${RD2C}/PUSH/NATIG/RC/code/helics/dnp3-application-helper-new.* ${RD2C}/ns-3-dev/contrib/helics/helper/
-cp -r ${RD2C}/PUSH/NATIG/RC/code/helics/dnp3-application-new* ${RD2C}/ns-3-dev/contrib/helics/model/
+cp -r ${NATIG_SRC}/RC/code/helics/helics-helper* ${RD2C}/ns-3-dev/contrib/helics/helper/
+cp -r ${NATIG_SRC}/RC/code/helics/dnp3-application-helper-new.* ${RD2C}/ns-3-dev/contrib/helics/helper/
+cp -r ${NATIG_SRC}/RC/code/helics/dnp3-application-new* ${RD2C}/ns-3-dev/contrib/helics/model/
 cp -r ${RD2C}/ns-3-dev/contrib/helics/model/dnp3-application-new.h ${RD2C}/ns-3-dev/contrib/helics/model/dnp3-application-new.h
 cp -r ${RD2C}/ns-3-dev/contrib/helics/model/dnp3-application-new.cc ${RD2C}/ns-3-dev/contrib/helics/model/dnp3-application-new.cc
-cp -r ${RD2C}/PUSH/NATIG/RC/code/helics/wscript ${RD2C}/ns-3-dev/contrib/helics/
-cp -r ${RD2C}/PUSH/NATIG/RC/code/helics/helics-simulator-impl.cc ${RD2C}/ns-3-dev/contrib/helics/model/
+cp -r ${NATIG_SRC}/RC/code/helics/wscript ${RD2C}/ns-3-dev/contrib/helics/
+cp -r ${NATIG_SRC}/RC/code/helics/helics-simulator-impl.cc ${RD2C}/ns-3-dev/contrib/helics/model/
 cd ${RD2C}/ns-3-dev
-cp -r ../PUSH/NATIG/RC/code/make.sh .
+cp -r ${NATIG_SRC}/RC/code/make.sh .
 mkdir ${RD2C}/ns-3-dev/src/dnp3/ 
-cp -r ../PUSH/NATIG/RC/code/dnp3/crypto ${RD2C}/ns-3-dev/src/dnp3  
-cp -r ../PUSH/NATIG/RC/code/dnp3/dnplib ${RD2C}/ns-3-dev/src/dnp3  
-cp -r ../PUSH/NATIG/RC/code/dnp3/examples ${RD2C}/ns-3-dev/src/dnp3 
-cp -r ../PUSH/NATIG/RC/code/dnp3/helper ${RD2C}/ns-3-dev/src/dnp3 
+cp -r ${NATIG_SRC}/RC/code/dnp3/crypto ${RD2C}/ns-3-dev/src/dnp3  
+cp -r ${NATIG_SRC}/RC/code/dnp3/dnplib ${RD2C}/ns-3-dev/src/dnp3  
+cp -r ${NATIG_SRC}/RC/code/dnp3/examples ${RD2C}/ns-3-dev/src/dnp3 
+cp -r ${NATIG_SRC}/RC/code/dnp3/helper ${RD2C}/ns-3-dev/src/dnp3 
 mkdir ${RD2C}/ns-3-dev/src/dnp3/model 
-cp -r ../PUSH/NATIG/RC/code/dnp3/wscript ${RD2C}/ns-3-dev/src/dnp3/ 
-cp -r ../PUSH/NATIG/RC/code/dnp3/model/dnp3-application.h ${RD2C}/ns-3-dev/src/dnp3/model/ 
-cp -r ../PUSH/NATIG/RC/code/dnp3/model/dnp3-application.cc ${RD2C}/ns-3-dev/src/dnp3/model/dnp3-application.cc 
-cp -r ../PUSH/NATIG/RC/code/dnp3/model/dnp3-application.cc ${RD2C}/ns-3-dev/src/dnp3/model/dnp3-application.cc 
-cp -r ../PUSH/NATIG/RC/code/dnp3/model/dnp3-simulator-impl.* ${RD2C}/ns-3-dev/src/dnp3/model/ 
-cp -r ../PUSH/NATIG/RC/code/dnp3/model/tcptest* ${RD2C}/ns-3-dev/src/dnp3/model/ 
-cp -r ../PUSH/NATIG/RC/code/dnp3/model/dnp3-mim-* ${RD2C}/ns-3-dev/src/dnp3/model/ 
-cp -r ../PUSH/NATIG/RC/code/internet/* ${RD2C}/ns-3-dev/src/internet/ 
-cp -r ../PUSH/NATIG/RC/code/lte/* ${RD2C}/ns-3-dev/src/lte/ 
-cp -r ../PUSH/NATIG/RC/code/dnp3/ src
-cp -r ../PUSH/NATIG/RC/code/dnp3/model/dnp3-application.cc src/dnp3/model/dnp3-application.cc
-cp -r ../PUSH/NATIG/RC/code/internet/ipv4-l3-protocol.* src/internet/model/
-cp -r ../PUSH/NATIG/RC/code/internet/internet-stack-helper-MIM.* src/internet/helper/
-cp -r ../PUSH/NATIG/RC/code/internet/wscript src/internet/
-cp -r ../PUSH/NATIG/RC/code/lte/* src/lte/
-cp -r ../PUSH/NATIG/RC/code/point-to-point-layout/* src/point-to-point-layout/
+cp -r ${NATIG_SRC}/RC/code/dnp3/wscript ${RD2C}/ns-3-dev/src/dnp3/ 
+cp -r ${NATIG_SRC}/RC/code/dnp3/model/dnp3-application.h ${RD2C}/ns-3-dev/src/dnp3/model/ 
+cp -r ${NATIG_SRC}/RC/code/dnp3/model/dnp3-application.cc ${RD2C}/ns-3-dev/src/dnp3/model/dnp3-application.cc 
+cp -r ${NATIG_SRC}/RC/code/dnp3/model/dnp3-application.cc ${RD2C}/ns-3-dev/src/dnp3/model/dnp3-application.cc 
+cp -r ${NATIG_SRC}/RC/code/dnp3/model/dnp3-simulator-impl.* ${RD2C}/ns-3-dev/src/dnp3/model/ 
+cp -r ${NATIG_SRC}/RC/code/dnp3/model/tcptest* ${RD2C}/ns-3-dev/src/dnp3/model/ 
+cp -r ${NATIG_SRC}/RC/code/dnp3/model/dnp3-mim-* ${RD2C}/ns-3-dev/src/dnp3/model/ 
+cp -r ${NATIG_SRC}/RC/code/internet/* ${RD2C}/ns-3-dev/src/internet/ 
+cp -r ${NATIG_SRC}/RC/code/lte/* ${RD2C}/ns-3-dev/src/lte/ 
+cp -r ${NATIG_SRC}/RC/code/dnp3/ src
+cp -r ${NATIG_SRC}/RC/code/dnp3/model/dnp3-application.cc src/dnp3/model/dnp3-application.cc
+cp -r ${NATIG_SRC}/RC/code/internet/ipv4-l3-protocol.* src/internet/model/
+cp -r ${NATIG_SRC}/RC/code/internet/internet-stack-helper-MIM.* src/internet/helper/
+cp -r ${NATIG_SRC}/RC/code/internet/wscript src/internet/
+cp -r ${NATIG_SRC}/RC/code/lte/* src/lte/
+cp -r ${NATIG_SRC}/RC/code/point-to-point-layout/* src/point-to-point-layout/
 mkdir src/dnp3/
-cp -r ../PUSH/NATIG/RC/code/dnp3/crypto src/dnp3
-cp -r ../PUSH/NATIG/RC/code/dnp3/dnplib src/dnp3
-cp -r ../PUSH/NATIG/RC/code/dnp3/examples src/dnp3
-cp -r ../PUSH/NATIG/RC/code/dnp3/helper src/dnp3
+cp -r ${NATIG_SRC}/RC/code/dnp3/crypto src/dnp3
+cp -r ${NATIG_SRC}/RC/code/dnp3/dnplib src/dnp3
+cp -r ${NATIG_SRC}/RC/code/dnp3/examples src/dnp3
+cp -r ${NATIG_SRC}/RC/code/dnp3/helper src/dnp3
 mkdir src/dnp3/model
-cp -r ../PUSH/NATIG/RC/code/dnp3/wscript src/dnp3/
-cp -r ../PUSH/NATIG/RC/code/dnp3/model/dnp3-application.h src/dnp3/model/
-cp -r ../PUSH/NATIG/RC/code/dnp3/model/dnp3-application.cc src/dnp3/model/dnp3-application.cc
-cp -r ../PUSH/NATIG/RC/code/dnp3/model/dnp3-application.cc src/dnp3/model/dnp3-application.cc
-cp -r ../PUSH/NATIG/RC/code/dnp3/model/dnp3-simulator-impl.* src/dnp3/model/
-cp -r ../PUSH/NATIG/RC/code/dnp3/model/tcptest* src/dnp3/model/
-cp -r ../PUSH/NATIG/RC/code/dnp3/model/dnp3-mim-* src/dnp3/model/
-cp -r ../PUSH/NATIG/RC/code/internet/* src/internet/
-cp -r ../PUSH/NATIG/RC/code/lte/* src/lte/
-cp -r ../PUSH/NATIG/RC/code/helics/helics-helper* /rd2c/ns-3-dev/contrib/helics/helper/
-cp -r ../PUSH/NATIG/RC/code/helics/dnp3-application-helper-new.* /rd2c/ns-3-dev/contrib/helics/helper/
-cp -r ../PUSH/NATIG/RC/code/helics/dnp3-application-new* /rd2c/ns-3-dev/contrib/helics/model/
-cp -r ../PUSH/NATIG/RC/code/helics/dnp3-application-new.cc /rd2c/ns-3-dev/contrib/helics/model/dnp3-application-new.cc
-cp -r ../PUSH/NATIG/RC/code/helics/dnp3-application-new.h /rd2c/ns-3-dev/contrib/helics/model/dnp3-application-new.h
-cp -r ../PUSH/NATIG/RC/code/helics/wscript /rd2c/ns-3-dev/contrib/helics/
+cp -r ${NATIG_SRC}/RC/code/dnp3/wscript src/dnp3/
+cp -r ${NATIG_SRC}/RC/code/dnp3/model/dnp3-application.h src/dnp3/model/
+cp -r ${NATIG_SRC}/RC/code/dnp3/model/dnp3-application.cc src/dnp3/model/dnp3-application.cc
+cp -r ${NATIG_SRC}/RC/code/dnp3/model/dnp3-application.cc src/dnp3/model/dnp3-application.cc
+cp -r ${NATIG_SRC}/RC/code/dnp3/model/dnp3-simulator-impl.* src/dnp3/model/
+cp -r ${NATIG_SRC}/RC/code/dnp3/model/tcptest* src/dnp3/model/
+cp -r ${NATIG_SRC}/RC/code/dnp3/model/dnp3-mim-* src/dnp3/model/
+cp -r ${NATIG_SRC}/RC/code/internet/* src/internet/
+cp -r ${NATIG_SRC}/RC/code/lte/* src/lte/
+cp -r ${NATIG_SRC}/RC/code/helics/helics-helper* /rd2c/ns-3-dev/contrib/helics/helper/
+cp -r ${NATIG_SRC}/RC/code/helics/dnp3-application-helper-new.* /rd2c/ns-3-dev/contrib/helics/helper/
+cp -r ${NATIG_SRC}/RC/code/helics/dnp3-application-new* /rd2c/ns-3-dev/contrib/helics/model/
+cp -r ${NATIG_SRC}/RC/code/helics/dnp3-application-new.cc /rd2c/ns-3-dev/contrib/helics/model/dnp3-application-new.cc
+cp -r ${NATIG_SRC}/RC/code/helics/dnp3-application-new.h /rd2c/ns-3-dev/contrib/helics/model/dnp3-application-new.h
+cp -r ${NATIG_SRC}/RC/code/helics/wscript /rd2c/ns-3-dev/contrib/helics/
 ./make.sh ${RD2C} 
 if [ "$1" == "5G" ]; then
     echo "installing 5G"
@@ -253,12 +254,12 @@ if [ "$1" == "5G" ]; then
     cd nr
     git checkout 5g-lena-v1.2.y
     cd ../../
-    cp -r ${RD2C}/PUSH/NATIG/patch/nr/* contrib/nr/
+    cp -r ${NATIG_SRC}/patch/nr/* contrib/nr/
     ./make.sh ${RD2C}
 fi
 
 #cd ../
 #cp -r PUSH/NATIG/integration/ .
 #cd integration/control/
-#cp ../../PUSH/NATIG/RC/code/ns3-helics-grid-dnp3-5G.cc .
-#cp ../../PUSH/NATIG/RC/code/ieee8500.glm .
+#cp ../${NATIG_SRC}/RC/code/ns3-helics-grid-dnp3-5G.cc .
+#cp ../${NATIG_SRC}/RC/code/ieee8500.glm .

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ cd <your_repo_name>
 
 # 2) Pull dependencies into the expected structure
 git clone https://github.com/nsnam/ns-3-dev-git.git ns-3-dev
-mkdir -p PUSH && cd PUSH
-git clone https://github.com/pnnl/NATIG.git
-cd ..
+# Optional: point scripts to this repo instead of /rd2c/PUSH/NATIG
+export NATIG_SRC=$(pwd)
+# If unset, scripts fall back to /rd2c/PUSH/NATIG
 
 # 3) Build the image  (⚠️ first time only – this is long!)
 docker build --network=host -f Dockerfile -t pnnl/natig:natigbase --no-cache .
@@ -89,18 +89,15 @@ cd <your_repo_name>
 
 ```bash
 git clone https://github.com/nsnam/ns-3-dev-git.git ns-3-dev
-mkdir PUSH && cd PUSH
-git clone https://github.com/pnnl/NATIG.git
-cd ..
+export NATIG_SRC=$(pwd)
+# If unset, scripts fall back to /rd2c/PUSH/NATIG
 ```
 
 Your tree now contains:
 
 ```
 <repo>
-├── ns-3-dev/
-└── PUSH/
-    └── NATIG/
+└── ns-3-dev/
 ```
 
 ### 3 · Build the Docker image
@@ -128,7 +125,7 @@ docker exec -it natigbase_container bash
 ### 6 · Compile ns-3 (one-time inside the container)
 
 ```bash
-cd /rd2c/PUSH/NATIG
+cd "$NATIG_SRC"
 ./build_ns3.sh "" /rd2c
 ```
 

--- a/build_helics.sh
+++ b/build_helics.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 
+# Path to the NATIG source (defaults to ${NATIG_SRC})
+NATIG_SRC="${NATIG_SRC:-${RD2C:-/rd2c}/PUSH/NATIG}"
+
 cd /rd2c/ns-3-dev/contrib/
 rm -r helics
 git clone --depth 1 --branch HELICS-v2.x-waf https://github.com/GMLC-TDC/helics-ns3.git; mv helics-ns3 helics
-cp -r /rd2c/PUSH/NATIG/RC/code/helics/helics-helper* /rd2c/ns-3-dev/contrib/helics/helper/
-cp -r /rd2c/PUSH/NATIG/RC/code/helics/dnp3-application-helper-new.* /rd2c/ns-3-dev/contrib/helics/helper/
-cp -r /rd2c/PUSH/NATIG/RC/code/helics/dnp3-application-new* /rd2c/ns-3-dev/contrib/helics/model/
+cp -r ${NATIG_SRC}/RC/code/helics/helics-helper* /rd2c/ns-3-dev/contrib/helics/helper/
+cp -r ${NATIG_SRC}/RC/code/helics/dnp3-application-helper-new.* /rd2c/ns-3-dev/contrib/helics/helper/
+cp -r ${NATIG_SRC}/RC/code/helics/dnp3-application-new* /rd2c/ns-3-dev/contrib/helics/model/
 cp -r /rd2c/ns-3-dev/contrib/helics/model/dnp3-application-new-Docker.h /rd2c/ns-3-dev/contrib/helics/model/dnp3-application-new.h
 cp -r /rd2c/ns-3-dev/contrib/helics/model/dnp3-application-new-Docker.cc /rd2c/ns-3-dev/contrib/helics/model/dnp3-application-new.cc
-cp -r /rd2c/PUSH/NATIG/RC/code/helics/wscript /rd2c/ns-3-dev/contrib/helics/
+cp -r ${NATIG_SRC}/RC/code/helics/wscript /rd2c/ns-3-dev/contrib/helics/
 echo "Applied HELICS wscript patch"
-cp -r /rd2c/PUSH/NATIG/RC/code/helics/helics-simulator-impl.cc /rd2c/ns-3-dev/contrib/helics/model/
+cp -r ${NATIG_SRC}/RC/code/helics/helics-simulator-impl.cc /rd2c/ns-3-dev/contrib/helics/model/

--- a/build_ns3.sh
+++ b/build_ns3.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Path to the NATIG source (defaults to /rd2c/PUSH/NATIG)
+NATIG_SRC="${NATIG_SRC:-${RD2C:-/rd2c}/PUSH/NATIG}"
+
 if [ -d "/rd2c/test" ]
 then
     rm -rf /rd2c/test/
@@ -22,38 +25,38 @@ git clone https://github.com/nsnam/ns-3-dev-git.git
 mv ns-3-dev-git ns-3-dev
 cd ns-3-dev
 git checkout ns-3.35
-cd /rd2c/PUSH/NATIG
+cd ${NATIG_SRC}
 ./build_helics.sh
 cd /rd2c/ns-3-dev
-cp -r ../PUSH/NATIG/RC/code/make.sh .
-cp -r ../PUSH/NATIG/RC/code/dnp3/ src
-cp -r ../PUSH/NATIG/RC/code/dnp3/model/dnp3-application-Docker.cc src/dnp3/model/dnp3-application.cc
-cp -r ../PUSH/NATIG/RC/code/internet/ipv4-l3-protocol* src/internet/model/
-cp -r ../PUSH/NATIG/RC/code/internet/internet-stack-helper-MIM.* src/internet/helper/
-cp -r ../PUSH/NATIG/RC/code/internet/wscript src/internet/
-cp -r ../PUSH/NATIG/RC/code/lte/* src/lte/
-cp -r ../PUSH/NATIG/RC/code/point-to-point-layout/* src/point-to-point-layout/
+cp -r ${NATIG_SRC}/RC/code/make.sh .
+cp -r ${NATIG_SRC}/RC/code/dnp3/ src
+cp -r ${NATIG_SRC}/RC/code/dnp3/model/dnp3-application-Docker.cc src/dnp3/model/dnp3-application.cc
+cp -r ${NATIG_SRC}/RC/code/internet/ipv4-l3-protocol* src/internet/model/
+cp -r ${NATIG_SRC}/RC/code/internet/internet-stack-helper-MIM.* src/internet/helper/
+cp -r ${NATIG_SRC}/RC/code/internet/wscript src/internet/
+cp -r ${NATIG_SRC}/RC/code/lte/* src/lte/
+cp -r ${NATIG_SRC}/RC/code/point-to-point-layout/* src/point-to-point-layout/
 mkdir src/dnp3/
-cp -r ../PUSH/NATIG/RC/code/dnp3/crypto src/dnp3
-cp -r ../PUSH/NATIG/RC/code/dnp3/dnplib src/dnp3
-cp -r ../PUSH/NATIG/RC/code/dnp3/examples src/dnp3
-cp -r ../PUSH/NATIG/RC/code/dnp3/helper src/dnp3
+cp -r ${NATIG_SRC}/RC/code/dnp3/crypto src/dnp3
+cp -r ${NATIG_SRC}/RC/code/dnp3/dnplib src/dnp3
+cp -r ${NATIG_SRC}/RC/code/dnp3/examples src/dnp3
+cp -r ${NATIG_SRC}/RC/code/dnp3/helper src/dnp3
 mkdir src/dnp3/model
-cp -r ../PUSH/NATIG/RC/code/dnp3/wscript src/dnp3/
-cp -r ../PUSH/NATIG/RC/code/dnp3/model/dnp3-application.h src/dnp3/model/
-cp -r ../PUSH/NATIG/RC/code/dnp3/model/dnp3-application-Docker.cc src/dnp3/model/dnp3-application.cc
-cp -r ../PUSH/NATIG/RC/code/dnp3/model/dnp3-application-Docker.cc src/dnp3/model/dnp3-application.cc
-cp -r ../PUSH/NATIG/RC/code/dnp3/model/dnp3-simulator-impl.* src/dnp3/model/
-cp -r ../PUSH/NATIG/RC/code/dnp3/model/tcptest* src/dnp3/model/
-cp -r ../PUSH/NATIG/RC/code/dnp3/model/dnp3-mim-* src/dnp3/model/
-cp -r ../PUSH/NATIG/RC/code/internet/* src/internet/
-cp -r ../PUSH/NATIG/RC/code/lte/* src/lte/
-cp -r /rd2c/PUSH/NATIG/RC/code/helics/helics-helper* /rd2c/ns-3-dev/contrib/helics/helper/
-cp -r /rd2c/PUSH/NATIG/RC/code/helics/dnp3-application-helper-new.* /rd2c/ns-3-dev/contrib/helics/helper/
-cp -r /rd2c/PUSH/NATIG/RC/code/helics/dnp3-application-new* /rd2c/ns-3-dev/contrib/helics/model/
-cp -r /rd2c/PUSH/NATIG/RC/code/helics/dnp3-application-new-Docker.cc /rd2c/ns-3-dev/contrib/helics/model/dnp3-application-new.cc
-cp -r /rd2c/PUSH/NATIG/RC/code/helics/dnp3-application-new-Docker.h /rd2c/ns-3-dev/contrib/helics/model/dnp3-application-new.h
-cp -r /rd2c/PUSH/NATIG/RC/code/helics/wscript /rd2c/ns-3-dev/contrib/helics/
+cp -r ${NATIG_SRC}/RC/code/dnp3/wscript src/dnp3/
+cp -r ${NATIG_SRC}/RC/code/dnp3/model/dnp3-application.h src/dnp3/model/
+cp -r ${NATIG_SRC}/RC/code/dnp3/model/dnp3-application-Docker.cc src/dnp3/model/dnp3-application.cc
+cp -r ${NATIG_SRC}/RC/code/dnp3/model/dnp3-application-Docker.cc src/dnp3/model/dnp3-application.cc
+cp -r ${NATIG_SRC}/RC/code/dnp3/model/dnp3-simulator-impl.* src/dnp3/model/
+cp -r ${NATIG_SRC}/RC/code/dnp3/model/tcptest* src/dnp3/model/
+cp -r ${NATIG_SRC}/RC/code/dnp3/model/dnp3-mim-* src/dnp3/model/
+cp -r ${NATIG_SRC}/RC/code/internet/* src/internet/
+cp -r ${NATIG_SRC}/RC/code/lte/* src/lte/
+cp -r ${NATIG_SRC}/RC/code/helics/helics-helper* /rd2c/ns-3-dev/contrib/helics/helper/
+cp -r ${NATIG_SRC}/RC/code/helics/dnp3-application-helper-new.* /rd2c/ns-3-dev/contrib/helics/helper/
+cp -r ${NATIG_SRC}/RC/code/helics/dnp3-application-new* /rd2c/ns-3-dev/contrib/helics/model/
+cp -r ${NATIG_SRC}/RC/code/helics/dnp3-application-new-Docker.cc /rd2c/ns-3-dev/contrib/helics/model/dnp3-application-new.cc
+cp -r ${NATIG_SRC}/RC/code/helics/dnp3-application-new-Docker.h /rd2c/ns-3-dev/contrib/helics/model/dnp3-application-new.h
+cp -r ${NATIG_SRC}/RC/code/helics/wscript /rd2c/ns-3-dev/contrib/helics/
 # Pass linker flags through sudo so that ns-3 builds with the proper libraries
 sudo env "LDFLAGS=$LDFLAGS" ./make.sh $2
 if [ "$1" == "5G" ]; then
@@ -64,7 +67,7 @@ if [ "$1" == "5G" ]; then
     cd nr
     git checkout 5g-lena-v1.2.y
     cd ../../
-    cp -r $2/PUSH/NATIG/patch/nr/* contrib/nr/
+    cp -r ${NATIG_SRC}/patch/nr/* contrib/nr/
     sudo env "LDFLAGS=$LDFLAGS" ./make.sh $2
 fi
 mkdir $2/integration/control/physicalDevOutput

--- a/integration/control/run.sh
+++ b/integration/control/run.sh
@@ -3,6 +3,7 @@
 #SBATCH --time=64:15:00
 # ==== set root and output
 export RD2C=$1
+NATIG_SRC="${NATIG_SRC:-${RD2C}/PUSH/NATIG}"
 export FNCS_INSTALL=${RD2C}
 export PATH=$PATH:${FNCS_INSTALL}/bin
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${FNCS_INSTALL}/lib
@@ -39,15 +40,15 @@ fi
 
 if [[ "$5" == "conf" ]]
 then
-cp ../../PUSH/NATIG/RC/code/points-${4}/* config/
+cp ${NATIG_SRC}/RC/code/points-${4}/* config/
 fi
 
 if [[ "$2" == "4G" ]]
 then
 if [[ "$5" == "conf" ]]
 then
-    cp -r ../../PUSH/NATIG/RC/code/4G-conf-${4}/*.json config/
-    cp -r ../../PUSH/NATIG/RC/code/4G-conf-${4}/*.glm .
+    cp -r ${NATIG_SRC}/RC/code/4G-conf-${4}/*.json config/
+    cp -r ${NATIG_SRC}/RC/code/4G-conf-${4}/*.glm .
 fi
 modelName="ns3-helics-grid-dnp3-4G"
 fi
@@ -55,8 +56,8 @@ if [[ "$2" == "5G" ]]
 then
 if [[ "$5" == "conf" ]]
 then
-    cp -r ../../PUSH/NATIG/RC/code/5G-conf-${4}/*.json config/
-    cp -r ../../PUSH/NATIG/RC/code/5G-conf-${4}/*.glm .
+    cp -r ${NATIG_SRC}/RC/code/5G-conf-${4}/*.json config/
+    cp -r ${NATIG_SRC}/RC/code/5G-conf-${4}/*.glm .
 fi
 modelName="ns3-helics-grid-dnp3-5G"
 fi
@@ -64,8 +65,8 @@ if [[ "$2" == "3G" ]]
 then
 if [[ "$5" == "conf" ]]
 then
-    cp -r ../../PUSH/NATIG/RC/code/3G-conf-${4}/*.json config/
-    cp -r ../../PUSH/NATIG/RC/code/3G-conf-${4}/*.glm .
+    cp -r ${NATIG_SRC}/RC/code/3G-conf-${4}/*.json config/
+    cp -r ${NATIG_SRC}/RC/code/3G-conf-${4}/*.glm .
 fi
 modelName="ns3-helics-grid-dnp3"
 fi

--- a/integration/control/run_ns3_only.sh
+++ b/integration/control/run_ns3_only.sh
@@ -5,6 +5,7 @@
 sudo bash killall.sh
 
 export RD2C=$1
+NATIG_SRC="${NATIG_SRC:-${RD2C}/PUSH/NATIG}"
 export FNCS_INSTALL=${RD2C}
 export PATH=$PATH:${FNCS_INSTALL}/bin
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${FNCS_INSTALL}/lib
@@ -37,20 +38,20 @@ fi
 
 if [[ "$2" == "4G" ]]
 then
-cp -r ../../PUSH/NATIG/RC/code/4G-conf-${4}/*.json config/
-cp -r ../../PUSH/NATIG/RC/code/4G-conf-${4}/*.glm .
+cp -r ${NATIG_SRC}/RC/code/4G-conf-${4}/*.json config/
+cp -r ${NATIG_SRC}/RC/code/4G-conf-${4}/*.glm .
 modelName="ns3-helics-grid-dnp3-4G"
 fi
 if [[ "$2" == "5G" ]]
 then
-cp -r ../../PUSH/NATIG/RC/code/5G-conf-${4}/*.json config/
-cp -r ../../PUSH/NATIG/RC/code/5G-conf-${4}/*.glm .
+cp -r ${NATIG_SRC}/RC/code/5G-conf-${4}/*.json config/
+cp -r ${NATIG_SRC}/RC/code/5G-conf-${4}/*.glm .
 modelName="ns3-helics-grid-dnp3-5G"
 fi
 if [[ "$2" == "3G" ]]
 then
-cp -r ../../PUSH/NATIG/RC/code/3G-conf-${4}/*.json config/
-cp -r ../../PUSH/NATIG/RC/code/3G-conf-${4}/*.glm .
+cp -r ${NATIG_SRC}/RC/code/3G-conf-${4}/*.json config/
+cp -r ${NATIG_SRC}/RC/code/3G-conf-${4}/*.glm .
 modelName="ns3-helics-grid-dnp3"
 fi
 

--- a/run_outside_docker.sh
+++ b/run_outside_docker.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 
+# Path to the NATIG source (defaults to ${NATIG_SRC})
+NATIG_SRC="${NATIG_SRC:-${RD2C:-/rd2c}/PUSH/NATIG}"
+
 echo "WARNING: If you use this script make sure to hardcode the port of helics in run.sh to the same value as the one set by brokerport in gridlabd_config.json"
 
 docker cp RC/code/$2 $1:/rd2c/integration/control/$3
 docker cp RC/code/run.sh $1:/rd2c/integration/control/
-docker cp RC/code/$4-conf-$5/ $1:/rd2c/PUSH/NATIG/RC/code/
+docker cp RC/code/$4-conf-$5/ $1:${NATIG_SRC}/RC/code/
 
 docker exec -i $1 /bin/sh -c "cd /rd2c/integration/control/;sudo bash run.sh /rd2c/ $4 \"RC\" $5 conf H "

--- a/update_workstation.sh
+++ b/update_workstation.sh
@@ -2,6 +2,8 @@
 
 git pull
 RD2C=${RD2C:-/rd2c}
+# Path to the NATIG source (defaults to $RD2C/PUSH/NATIG)
+NATIG_SRC="${NATIG_SRC:-${RD2C}/PUSH/NATIG}"
 
 read -p "Do you want to save your current setup? [y/n] " answer
 
@@ -45,13 +47,13 @@ cp -r RC/code/internet/* ${RD2C}/ns-3-dev/src/internet/
 cp -r RC/code/lte/* ${RD2C}/ns-3-dev/src/lte/ 
 cp -r RC/code/gridlabd/* ${RD2C}/gridlab-d/tape_file/ 
 cp -r RC/code/trigger.player ${RD2C}/integration/control/
-cd ${RD2C}/PUSH/NATIG
+cd ${NATIG_SRC}
 ./build_helics.sh
 cd ${RD2C}/ns-3-dev
-cp -r ${RD2C}/PUSH/NATIG/RC/code/helics/helics-helper* ${RD2C}/ns-3-dev/contrib/helics/helper/
-cp -r ${RD2C}/PUSH/NATIG/RC/code/helics/dnp3-application-helper-new.* ${RD2C}/ns-3-dev/contrib/helics/helper/
-cp -r ${RD2C}/PUSH/NATIG/RC/code/helics/dnp3-application-new* ${RD2C}/ns-3-dev/contrib/helics/model/
-cp -r ${RD2C}/PUSH/NATIG/RC/code/helics/wscript ${RD2C}/ns-3-dev/contrib/helics/
+cp -r ${NATIG_SRC}/RC/code/helics/helics-helper* ${RD2C}/ns-3-dev/contrib/helics/helper/
+cp -r ${NATIG_SRC}/RC/code/helics/dnp3-application-helper-new.* ${RD2C}/ns-3-dev/contrib/helics/helper/
+cp -r ${NATIG_SRC}/RC/code/helics/dnp3-application-new* ${RD2C}/ns-3-dev/contrib/helics/model/
+cp -r ${NATIG_SRC}/RC/code/helics/wscript ${RD2C}/ns-3-dev/contrib/helics/
 
 
 #if [ -d "${RD2C}/gridlab-d/third_party/xerces-c-3.2.0" ]; then
@@ -77,7 +79,7 @@ cp -r ${RD2C}/PUSH/NATIG/RC/code/helics/wscript ${RD2C}/ns-3-dev/contrib/helics/
 #
 ## Export linker flags so ns-3 picks them up during the build
 #export LDFLAGS="-ljsoncpp -L/usr/local/include/jsoncpp/"
-#cd $RD2C/PUSH/NATIG
+#cd $RD${NATIG_SRC}
 #./build_ns3.sh "$1" ${RD2C}
 #
 ## Remove ns-3 build directory to save disk space


### PR DESCRIPTION
## Summary
- allow overriding NATIG repo location via `NATIG_SRC` env var
- update build and run scripts to use `NATIG_SRC`
- revise docs to describe the new variable and no longer clone a second repo
- add root `AGENTS.md`

## Testing
- `shellcheck RC/make.sh build_ns3.sh build_helics.sh update_workstation.sh RC/code/run.sh RC/code/pythonFederate/tutorial.sh integration/control/run.sh integration/control/run_ns3_only.sh run_outside_docker.sh`
- `mdl README.md EXAMPLES.md`

------
https://chatgpt.com/codex/tasks/task_e_6849cdedc79c832fb3a00b6da82fab8c