### PR TITLE
Add crypto files to modbus build list

### DIFF
--- a/patch/modbus/wscript
+++ b/patch/modbus/wscript
@@ -32,6 +32,11 @@ def build(bld):
         'helper/dnp3-application-helper.cc',
         'helper/dnp3-mim-application-helper.cc',
         'helper/modbus-helper.cc',
+        'crypto/aes.c',
+        'crypto/sha1.c',
+        'crypto/sha2.c',
+        'crypto/wrap.c',
+        'crypto/temp_wrap.c',
         ]
 
     headers = bld(features='ns3header')
@@ -64,6 +69,10 @@ def build(bld):
         'model/modbus-master-app.h',
         'model/modbus-slave-app.h',
         'model/tcptest-application.h',
+        'crypto/aes.h',
+        'crypto/sha1.h',
+        'crypto/sha2.h',
+        'crypto/wrap.h',
         ]
 
     #if bld.env.ENABLE_EXAMPLES:


### PR DESCRIPTION
## Summary
- include crypto sources in `patch/modbus/wscript`
- include crypto headers in `patch/modbus/wscript`

## Testing
- `bash develop.sh` *(fails: /rd2c/build_helics.sh not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a27f6fbac832fb5ab70ceb3b8539b