### PR TITLE
Fix HELICS build script path

### DIFF
--- a/build_helics.sh
+++ b/build_helics.sh
@@ -5,14 +5,14 @@
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 NATIG_SRC="${NATIG_SRC:-${SCRIPT_DIR}}"
 
-cd /rd2c/ns-3-dev/contrib/
+cd /rd2c/ns-3-dev/contrib/ || exit
 rm -r helics
 git clone --depth 1 --branch HELICS-v2.x-waf https://github.com/GMLC-TDC/helics-ns3.git; mv helics-ns3 helics
-cp -r ${NATIG_SRC}/RC/code/helics/helics-helper* /rd2c/ns-3-dev/contrib/helics/helper/
-cp -r ${NATIG_SRC}/RC/code/helics/dnp3-application-helper-new.* /rd2c/ns-3-dev/contrib/helics/helper/
-cp -r ${NATIG_SRC}/RC/code/helics/dnp3-application-new* /rd2c/ns-3-dev/contrib/helics/model/
+cp -r "${NATIG_SRC}"/RC/code/helics/helics-helper* /rd2c/ns-3-dev/contrib/helics/helper/
+cp -r "${NATIG_SRC}"/RC/code/helics/dnp3-application-helper-new.* /rd2c/ns-3-dev/contrib/helics/helper/
+cp -r "${NATIG_SRC}"/RC/code/helics/dnp3-application-new* /rd2c/ns-3-dev/contrib/helics/model/
 cp -r /rd2c/ns-3-dev/contrib/helics/model/dnp3-application-new-Docker.h /rd2c/ns-3-dev/contrib/helics/model/dnp3-application-new.h
 cp -r /rd2c/ns-3-dev/contrib/helics/model/dnp3-application-new-Docker.cc /rd2c/ns-3-dev/contrib/helics/model/dnp3-application-new.cc
-cp -r /RC/code/helics/wscript /rd2c/ns-3-dev/contrib/helics/
+cp -r "${NATIG_SRC}/RC/code/helics/wscript" /rd2c/ns-3-dev/contrib/helics/
 echo "Applied HELICS wscript patch"
-cp -r ${NATIG_SRC}/RC/code/helics/helics-simulator-impl.cc /rd2c/ns-3-dev/contrib/helics/model/
+cp -r "${NATIG_SRC}"/RC/code/helics/helics-simulator-impl.cc /rd2c/ns-3-dev/contrib/helics/model/


### PR DESCRIPTION
## Summary
- fix path to wscript in `build_helics.sh`
- improve quoting and ensure directory changes exit on failure

## Testing
- `shellcheck build_helics.sh`
- `markdownlint -V`

------
https://chatgpt.com/codex/tasks/task_e_684a2cebe9a0832f9407ca7742b1c3b7