### PR TITLE
Fix security build errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,28 @@
 # Codex Agent Instructions
 
-When modifying any `*.sh` script within this repository, run `shellcheck` on the modified files and address warnings where possible.
+When modifying any `*.sh` script within this repository, run
+`shellcheck` on the modified files and address warnings where
+possible.
 
-When modifying Markdown files (`*.md`), run `markdownlint` on the changed files.
+When modifying Markdown files (`*.md`), run `markdownlint` on
+changed files.
 
 Always run these checks before committing your changes.
+
+## Local Docker Setup
+
+Many build scripts expect the repository root to be mounted to
+`/rd2c` inside a Docker container. The helper script `rundocker.sh`
+launches this container with a bind mount of the current repository
+directory to `/rd2c` (see `Dockerfile` for the base image details).
+Scripts therefore refer to paths such as `/rd2c/build_helics.sh`
+even though `build_helics.sh` lives at the repository root.
+
+Keep this mount in mind when running `develop.sh` or related scripts
+so that path lookups succeed.
+
+The `ns-3-dev` directory is intentionally excluded from version control
+(see `.gitignore`). For builds to succeed, place your local `ns-3-dev`
+checkout inside the repository root. When launched via `rundocker.sh`,
+this directory will appear inside the container as `/rd2c/ns-3-dev`,
+which is the location expected by `develop.sh` and other scripts.

--- a/patch/modbus/dnplib/master.cpp
+++ b/patch/modbus/dnplib/master.cpp
@@ -101,6 +101,7 @@ DnpStat_t Master::getSecAuthStat( DnpAddr_t stationAddr, int index)
 #ifdef SECURITY_ENABLED
     return stationMap[ stationAddr]->secAuth.stats.get( index);
 #endif
+    return 0;
 }
 
 DnpStat_t Master::getState() const
@@ -113,6 +114,7 @@ DnpStat_t Master::getSecAuthState() const
 #ifdef SECURITY_ENABLED
     return stn_p->secAuth.stats.get(SecureAuthentication::STATE);
 #endif
+    return 0;
 }
 
 DnpStat_t Master::rxData(Bytes* buf, Uptime_t timeRxd)

--- a/patch/modbus/dnplib/master.hpp
+++ b/patch/modbus/dnplib/master.hpp
@@ -44,7 +44,7 @@ namespace ns3 {
 // none of the states or methods are timing dependent to facilitate
 // debugging
 // this class is NOT reentrant
-class Master : BaseApplication
+class Master : public BaseApplication
 {
 public:
 
@@ -97,11 +97,9 @@ public:
     void transmitEmpty(Lpdu::UserData data);
 
 private:
-#ifdef SECURITY_ENABLED
     friend class SecureAuthentication;
     friend class MasterSecurity;
     friend class TestSecurity;
-#endif
     friend class TestMaster;
     
 

--- a/patch/modbus/dnplib/outstation.hpp
+++ b/patch/modbus/dnplib/outstation.hpp
@@ -48,7 +48,7 @@ using namespace std;
 
 namespace ns3 {
 
-class Outstation : BaseApplication
+class Outstation : public BaseApplication
 {
 public:
     static const unsigned int MAX_POINTS      = 79;
@@ -160,10 +160,8 @@ public:
     void set_stationName(string name);
     void set_publishCallback(const std::function<void(std::string, std::string, std::string)>& callback);
 private:
-#ifdef SECURITY_ENABLED
     friend class SecureAuthentication;
     friend class OutstationSecurity;
-#endif
     // call when a new fragment has been rxd by the transport function
     void processRxdFragment(map<string, float> analog_points, map<string, uint16_t> bin_points);
 

--- a/patch/modbus/dnplib/security.cpp
+++ b/patch/modbus/dnplib/security.cpp
@@ -899,8 +899,7 @@ MasterSecurity::MasterSecurity(Master* app_p, bool aggressiveMode) :
     assert (sizeof(temp)/sizeof(Stats::Element) == NUM_STATS);
     memcpy(statElements, temp, sizeof(temp));
     // MA - Master Authentication
-    //snprintf(name, sizeof(name), "MA %6d ", app_p->addr);
-    app_p->addr.CopyTo((unsigned char*)name);
+    snprintf(name, sizeof(name), "MA %6d ", app_p->addr);
     stats = Stats( name, app_p->addr, app_p->debug_p, statElements, NUM_STATS,
 		   app_p->db_p, EventInterface::SA_AB_ST);
 }
@@ -1134,8 +1133,7 @@ OutstationSecurity::OutstationSecurity(Outstation* app_p, bool aggressiveMode):
     assert (sizeof(temp)/sizeof(Stats::Element) == NUM_STATS);
     memcpy(statElements, temp, sizeof(temp));
     // OA - Outstation Authentication
-    //snprintf(name, sizeof(name), "OA %6d ", app_p->addr);
-    app_p->addr.CopyTo((unsigned char*)name);
+    snprintf(name, sizeof(name), "OA %6d ", app_p->addr);
     stats = Stats( name, app_p->addr, app_p->debug_p, statElements, NUM_STATS,
 		   app_p->db_p, EventInterface::SA_AB_ST);
 

--- a/patch/modbus/model/dnp3-mim-application.cc
+++ b/patch/modbus/model/dnp3-mim-application.cc
@@ -50,7 +50,7 @@ using namespace std;
 #include "ns3/event_interface.hpp"
 #include "ns3/object.hpp"
 #include "ns3/asdu.hpp"
-#include "ns3/global-variables.h"
+// #include "ns3/global-variables.h"
 
 
 namespace ns3 {

--- a/patch/modbus/wscript
+++ b/patch/modbus/wscript
@@ -1,5 +1,8 @@
 ## -*- Mode: python; py-indent-offset: 4; indent-tabs-mode: nil; coding: utf-8; -*-
 
+def configure(conf):
+    conf.env.append_value('CXXDEFINES', 'SECURITY_ENABLED')
+
 def build(bld):
     module = bld.create_ns3_module('modbus', ['core', 'network', 'internet', 'point-to-point', 'helics'])
 
@@ -32,6 +35,11 @@ def build(bld):
         'helper/dnp3-application-helper.cc',
         'helper/dnp3-mim-application-helper.cc',
         'helper/modbus-helper.cc',
+        'crypto/aes.c',
+        'crypto/sha1.c',
+        'crypto/sha2.c',
+        'crypto/wrap.c',
+        'crypto/temp_wrap.c',
         ]
 
     headers = bld(features='ns3header')
@@ -64,6 +72,10 @@ def build(bld):
         'model/modbus-master-app.h',
         'model/modbus-slave-app.h',
         'model/tcptest-application.h',
+        'crypto/aes.h',
+        'crypto/sha1.h',
+        'crypto/sha2.h',
+        'crypto/wrap.h',
         ]
 
     #if bld.env.ENABLE_EXAMPLES:


### PR DESCRIPTION
## Summary
- return zero when secure auth is disabled
- format security stats names using snprintf
- comment out missing global variables include
- document local ns-3-dev path required for build

## Testing
- ✅ `markdownlint AGENTS.md`
- ❌ `bash develop.sh` (failed to locate ns-3-dev)

------
https://chatgpt.com/codex/tasks/task_e_684a27f6fbac832fb5ab70ceb3b8539b