### PR TITLE
Fix missing GetPacket methods in icmpv6 headers

### DIFF
--- a/patch/internet/model/icmpv6-header.cc
+++ b/patch/internet/model/icmpv6-header.cc
@@ -1076,6 +1076,12 @@ void Icmpv6DestinationUnreachable::SetPacket (Ptr<Packet> p)
   m_packet = p->Copy ();
 }
 
+Ptr<Packet> Icmpv6DestinationUnreachable::GetPacket () const
+{
+  NS_LOG_FUNCTION (this);
+  return m_packet;
+}
+
 void Icmpv6DestinationUnreachable::Print (std::ostream& os) const
 {
   NS_LOG_FUNCTION (this << &os);
@@ -1169,6 +1175,12 @@ void Icmpv6TooBig::SetPacket (Ptr<Packet> p)
   NS_LOG_FUNCTION (this << *p);
   NS_ASSERT (p->GetSize () <= 1280);
   m_packet = p->Copy ();
+}
+
+Ptr<Packet> Icmpv6TooBig::GetPacket () const
+{
+  NS_LOG_FUNCTION (this);
+  return m_packet;
 }
 
 uint32_t Icmpv6TooBig::GetMtu () const
@@ -1271,11 +1283,17 @@ Icmpv6TimeExceeded::~Icmpv6TimeExceeded ()
 }
 
 
-void Icmpv6TimeExceeded::SetPacket (Ptr<Packet> p) 
+void Icmpv6TimeExceeded::SetPacket (Ptr<Packet> p)
 {
   NS_LOG_FUNCTION (this << *p);
   NS_ASSERT (p->GetSize () <= 1280);
   m_packet = p->Copy ();
+}
+
+Ptr<Packet> Icmpv6TimeExceeded::GetPacket () const
+{
+  NS_LOG_FUNCTION (this);
+  return m_packet;
 }
 
 void Icmpv6TimeExceeded::Print (std::ostream& os) const
@@ -1371,6 +1389,12 @@ void Icmpv6ParameterError::SetPacket (Ptr<Packet> p)
   NS_LOG_FUNCTION (this << *p);
   NS_ASSERT (p->GetSize () <= 1280);
   m_packet = p->Copy ();
+}
+
+Ptr<Packet> Icmpv6ParameterError::GetPacket () const
+{
+  NS_LOG_FUNCTION (this);
+  return m_packet;
 }
 
 uint32_t Icmpv6ParameterError::GetPtr () const
@@ -1938,6 +1962,12 @@ void Icmpv6OptionRedirected::SetPacket (Ptr<Packet> packet)
   NS_ASSERT (packet->GetSize () <= 1280);
   m_packet = packet->Copy ();
   SetLength (1 + (m_packet->GetSize () / 8));
+}
+
+Ptr<Packet> Icmpv6OptionRedirected::GetPacket () const
+{
+  NS_LOG_FUNCTION (this);
+  return m_packet;
 }
 
 void Icmpv6OptionRedirected::Print (std::ostream& os) const

--- a/patch/internet/model/icmpv6-header.h
+++ b/patch/internet/model/icmpv6-header.h
@@ -1065,6 +1065,11 @@ public:
    * \param p the incorrect packet
    */
   void SetPacket (Ptr<Packet> p);
+  /**
+   * \brief Get the packet that triggered the error.
+   * \return stored packet copy
+   */
+  Ptr<Packet> GetPacket () const;
 
   /**
    * \brief Print information.
@@ -1133,6 +1138,11 @@ public:
    * \param p the incorrect packet
    */
   void SetPacket (Ptr<Packet> p);
+  /**
+   * \brief Get the offending packet for this error message.
+   * \return stored packet
+   */
+  Ptr<Packet> GetPacket () const;
 
   /**
    * \brief Get the MTU field.
@@ -1219,6 +1229,11 @@ public:
    * \param p the incorrect packet
    */
   void SetPacket (Ptr<Packet> p);
+  /**
+   * \brief Retrieve the packet that triggered the error.
+   * \return stored packet
+   */
+  Ptr<Packet> GetPacket () const;
 
   /**
    * \brief Print information.
@@ -1288,6 +1303,11 @@ public:
    * \param p the incorrect packet
    */
   void SetPacket (Ptr<Packet> p);
+  /**
+   * \brief Access the incorrect packet stored in this header.
+   * \return stored packet copy
+   */
+  Ptr<Packet> GetPacket () const;
 
   /**
    * \brief Get the pointer field.
@@ -1735,6 +1755,11 @@ public:
    * \param packet the redirected packet
    */
   void SetPacket (Ptr<Packet> packet);
+  /**
+   * \brief Return the redirected packet stored in this option.
+   * \return redirected packet
+   */
+  Ptr<Packet> GetPacket () const;
 
   /**
    * \brief Print information.


### PR DESCRIPTION
## Summary
- implement `GetPacket()` accessors for several icmpv6 headers
- expose new methods in corresponding source file

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a4dd3a21c832f864575fa7e994582