### PR TITLE
Add LDFLAGS setup to develop.sh

### DIFF
--- a/develop.sh
+++ b/develop.sh
@@ -72,6 +72,7 @@ cd ${RD2C_DIR}/ns-3-dev
 
 # THIS IS THE FINAL FIX: Pass CXXFLAGS directly to configure
 echo "Configuring new build..."
+export LDFLAGS="-L/usr/local/lib -lhelicsSharedLib -ljsoncpp${LDFLAGS:+ $LDFLAGS}"
 CXXFLAGS="-I/usr/local/include" ./waf configure --enable-examples --enable-tests --disable-fncs
 
 echo "Building ns-3..."


### PR DESCRIPTION
## Summary
- export `LDFLAGS` before running `./waf configure`
- run shellcheck

## Testing
- `shellcheck develop.sh`

------
https://chatgpt.com/codex/tasks/task_e_684a7e002270832faa0fda120b254d2a