### PR TITLE
Update helics module build configuration

### DIFF
--- a/RC/code/helics/wscript
+++ b/RC/code/helics/wscript
@@ -1,7 +1,13 @@
+def configure(conf):
+    conf.env['LIBPATH_HELICS'] = ['/usr/local/lib']
+    conf.env['LIB_HELICS'] = ['helicsSharedLib']
+    conf.env['LIB_JSONCPP'] = ['jsoncpp']
+    conf.env['ENABLE_HELICS'] = True
+
 def build(bld):
     # Build the HELICS module without any additional examples
     module = bld.create_ns3_module('helics', ['core', 'network', 'internet'])
-    module.use.extend(['helicsSharedLib', 'jsoncpp'])
+    module.use.extend(['HELICS', 'JSONCPP'])
     module.source = [
         'model/helics-application.cc',
         'model/helics-static-source-application.cc',


### PR DESCRIPTION
## Summary
- add a configure() function to export HELICS-related vars
- use HELICS/JSONCPP names in module.use

## Testing
- `python3 -m py_compile RC/code/helics/wscript`


------
https://chatgpt.com/codex/tasks/task_e_684a81a8866c832fb513c9c93ceb5fec