### PR TITLE
Fix build_ns3.sh

### DIFF
--- a/build_ns3.sh
+++ b/build_ns3.sh
@@ -18,39 +18,41 @@ then
     rm -rf /rd2c/ns-3-dev-git/
 fi
 
-cd ../../
+cd ../../ || exit
 #mkdir test
-#cd test 
+#cd test
 git clone https://github.com/nsnam/ns-3-dev-git.git
 mv ns-3-dev-git ns-3-dev
-cd ns-3-dev
+cd ns-3-dev || exit
 git checkout ns-3.35
-cd ${NATIG_SRC}
+cd "${NATIG_SRC}" || exit
 ./build_helics.sh
-cd /rd2c/ns-3-dev
-cp -r ${NATIG_SRC}/RC/code/make.sh .
-cp -r ${NATIG_SRC}/RC/code/dnp3/ src
-cp -r ${NATIG_SRC}/RC/code/dnp3/model/dnp3-application-Docker.cc src/dnp3/model/dnp3-application.cc
-cp -r ${NATIG_SRC}/RC/code/internet/ipv4-l3-protocol* src/internet/model/
-cp -r ${NATIG_SRC}/RC/code/internet/internet-stack-helper-MIM.* src/internet/helper/
-cp -r ${NATIG_SRC}/RC/code/internet/wscript src/internet/
-cp -r ${NATIG_SRC}/RC/code/lte/* src/lte/
-cp -r ${NATIG_SRC}/RC/code/point-to-point-layout/* src/point-to-point-layout/
-mkdir src/dnp3/
-cp -r ${NATIG_SRC}/RC/code/dnp3/crypto src/dnp3
-cp -r ${NATIG_SRC}/RC/code/dnp3/dnplib src/dnp3
-cp -r ${NATIG_SRC}/RC/code/dnp3/examples src/dnp3
-cp -r ${NATIG_SRC}/RC/code/dnp3/helper src/dnp3
-mkdir src/dnp3/model
-cp -r ${NATIG_SRC}/RC/code/dnp3/wscript src/dnp3/
-cp -r ${NATIG_SRC}/RC/code/dnp3/model/dnp3-application.h src/dnp3/model/
-cp -r ${NATIG_SRC}/RC/code/dnp3/model/dnp3-application-Docker.cc src/dnp3/model/dnp3-application.cc
-cp -r ${NATIG_SRC}/RC/code/dnp3/model/dnp3-application-Docker.cc src/dnp3/model/dnp3-application.cc
-cp -r ${NATIG_SRC}/RC/code/dnp3/model/dnp3-simulator-impl.* src/dnp3/model/
-cp -r ${NATIG_SRC}/RC/code/dnp3/model/tcptest* src/dnp3/model/
-cp -r ${NATIG_SRC}/RC/code/dnp3/model/dnp3-mim-* src/dnp3/model/
-cp -r ${NATIG_SRC}/RC/code/internet/* src/internet/
-cp -r ${NATIG_SRC}/RC/code/lte/* src/lte/
+cd /rd2c/ns-3-dev || exit
+cp -r "${NATIG_SRC}"/RC/code/make.sh .
+# The following block copied the DNP3 sources and wscript into ns-3-dev.
+# It has been disabled to avoid creating the src/dnp3 directory.
+# cp -r "${NATIG_SRC}"/RC/code/dnp3/ src
+# cp -r "${NATIG_SRC}"/RC/code/dnp3/model/dnp3-application-Docker.cc src/dnp3/model/dnp3-application.cc
+cp -r "${NATIG_SRC}"/RC/code/internet/ipv4-l3-protocol* src/internet/model/
+cp -r "${NATIG_SRC}"/RC/code/internet/internet-stack-helper-MIM.* src/internet/helper/
+cp -r "${NATIG_SRC}"/RC/code/internet/wscript src/internet/
+cp -r "${NATIG_SRC}"/RC/code/lte/* src/lte/
+cp -r "${NATIG_SRC}"/RC/code/point-to-point-layout/* src/point-to-point-layout/
+# mkdir src/dnp3/
+# cp -r "${NATIG_SRC}"/RC/code/dnp3/crypto src/dnp3
+# cp -r "${NATIG_SRC}"/RC/code/dnp3/dnplib src/dnp3
+# cp -r "${NATIG_SRC}"/RC/code/dnp3/examples src/dnp3
+# cp -r "${NATIG_SRC}"/RC/code/dnp3/helper src/dnp3
+# mkdir src/dnp3/model
+# cp -r "${NATIG_SRC}"/RC/code/dnp3/wscript src/dnp3/
+# cp -r "${NATIG_SRC}"/RC/code/dnp3/model/dnp3-application.h src/dnp3/model/
+# cp -r "${NATIG_SRC}"/RC/code/dnp3/model/dnp3-application-Docker.cc src/dnp3/model/dnp3-application.cc
+# cp -r "${NATIG_SRC}"/RC/code/dnp3/model/dnp3-application-Docker.cc src/dnp3/model/dnp3-application.cc
+# cp -r "${NATIG_SRC}"/RC/code/dnp3/model/dnp3-simulator-impl.* src/dnp3/model/
+# cp -r "${NATIG_SRC}"/RC/code/dnp3/model/tcptest* src/dnp3/model/
+# cp -r "${NATIG_SRC}"/RC/code/dnp3/model/dnp3-mim-* src/dnp3/model/
+cp -r "${NATIG_SRC}"/RC/code/internet/* src/internet/
+cp -r "${NATIG_SRC}"/RC/code/lte/* src/lte/
 cp -r "${NATIG_SRC}"/RC/code/helics/helics-helper* /rd2c/ns-3-dev/contrib/helics/helper/
 cp -r "${NATIG_SRC}"/RC/code/helics/wscript /rd2c/ns-3-dev/contrib/helics/
 # Pass linker flags through sudo so that ns-3 builds with the proper libraries


### PR DESCRIPTION
## Summary
- stop copying dnp3 sources into ns-3-dev
- quote variables and add `cd` fallbacks
- run `shellcheck` with no warnings

## Testing
- `shellcheck build_ns3.sh`

------
https://chatgpt.com/codex/tasks/task_e_68505dc1c968832fa8e5cdca66332265