### PR TITLE
Update run scripts for Modbus

### DIFF
--- a/RC/code/pythonFederate/tutorial.sh
+++ b/RC/code/pythonFederate/tutorial.sh
@@ -46,7 +46,7 @@ then
     cp -r ${NATIG_SRC}/RC/code/4G-conf-${4}/*.json config/
     cp -r ${NATIG_SRC}/RC/code/4G-conf-${4}/*.glm .
 fi
-modelName="ns3-helics-grid-dnp3-4G"
+modelName="ns3-helics-grid-modbus-4G"
 fi
 if [[ "$2" == "5G" ]]
 then
@@ -55,7 +55,7 @@ then
     cp -r ${NATIG_SRC}/RC/code/5G-conf-${4}/*.json config/
     cp -r ${NATIG_SRC}/RC/code/5G-conf-${4}/*.glm .
 fi
-modelName="ns3-helics-grid-dnp3-5G"
+modelName="ns3-helics-grid-modbus-5G"
 fi
 if [[ "$2" == "3G" ]]
 then
@@ -64,7 +64,7 @@ then
     cp -r ${NATIG_SRC}/RC/code/3G-conf-${4}/*.json config/
     cp -r ${NATIG_SRC}/RC/code/3G-conf-${4}/*.glm .
 fi
-modelName="ns3-helics-grid-dnp3"
+modelName="ns3-helics-grid-modbus"
 fi
 
 #sbatch run-helics.sh ${helicsLOGlevel} ${helicsOutFile}
@@ -73,7 +73,7 @@ v2=$( grep 'brokerPort' ${PWD}/config/gridlabd_config.json | sed -r 's/^[^:]*:(.
 cd ${ROOT_PATH} && \
 helics_broker --slowresponding --federates=2 --port=$v2 --loglevel=${helicsLOGlevel} >> ${helicsOutFile} 2>&1 & \
  #helics_app tracer test.txt --config-file endpoints.txt --loglevel 7 --timedelta 1 >> tracer.txt 2>&1 & \
-cd -
+cd - || exit
 
 # ===== starting GridLAB-D ===== 
 gldDir="${ROOT_PATH}"
@@ -94,7 +94,7 @@ fi
 #sbatch run-gridlabd.sh ${OUT_DIR} ${gldModelFile} ${gldOutFile}
 cd ${gldDir} && \
    gridlabd -D OUT_FOLDER=${OUT_DIR} ${gldModelFile} >> ${gldOutFile} 2>&1 & \
-   cd -
+   cd - || exit
 
 
 

--- a/RC/code/run.sh
+++ b/RC/code/run.sh
@@ -50,7 +50,7 @@ then
     cp -r ${NATIG_SRC}/RC/code/4G-conf-${4}/*.json config/
     cp -r ${NATIG_SRC}/RC/code/4G-conf-${4}/*.glm .
 fi
-modelName="ns3-helics-grid-dnp3-4G"
+modelName="ns3-helics-grid-modbus-4G"
 fi
 if [[ "$2" == "5G" ]]
 then
@@ -59,7 +59,7 @@ then
     cp -r ${NATIG_SRC}/RC/code/5G-conf-${4}/*.json config/
     cp -r ${NATIG_SRC}/RC/code/5G-conf-${4}/*.glm .
 fi
-modelName="ns3-helics-grid-dnp3-5G"
+modelName="ns3-helics-grid-modbus-5G"
 fi
 if [[ "$2" == "3G" ]]
 then
@@ -68,7 +68,7 @@ then
     cp -r ${NATIG_SRC}/RC/code/3G-conf-${4}/*.json config/
     cp -r ${NATIG_SRC}/RC/code/3G-conf-${4}/*.glm .
 fi
-modelName="ns3-helics-grid-dnp3"
+modelName="ns3-helics-grid-modbus"
 fi
 
 #sbatch run-helics.sh ${helicsLOGlevel} ${helicsOutFile}
@@ -82,7 +82,7 @@ helics_broker --slowresponding --federates=2 --port=$v2 --loglevel=${helicsLOGle
 #helics_broker --slowresponding --federates=2 --port=9000 --loglevel=${helicsLOGlevel} >> ${helicsOutFile} 2>&1 & \
 #fi
  #helics_app tracer test.txt --config-file endpoints.txt --loglevel 7 --timedelta 1 >> tracer.txt 2>&1 & \
-cd -
+cd - || exit
 
 # ===== starting GridLAB-D ===== 
 gldDir="${ROOT_PATH}"
@@ -103,7 +103,7 @@ fi
 #sbatch run-gridlabd.sh ${OUT_DIR} ${gldModelFile} ${gldOutFile}
 cd ${gldDir} && \
    gridlabd -D OUT_FOLDER=${OUT_DIR} ${gldModelFile} >> ${gldOutFile} 2>&1 & \
-   cd -
+   cd - || exit
 
 
 # ccDir="${ROOT_PATH}"
@@ -145,7 +145,7 @@ cd ${ns3Dir} && \
 cp ${ROOT_PATH}/${modelName}.cc ${ns3Model}.cc && \
 ./make.sh "$1" && \
   ./waf --run "scratch/${modelName} --helicsConfig=${helicsConfig} --microGridConfig=${microGridConfig} --topologyConfig=${topologyConfig} --pointFileDir=${configDir} --pcapFileDir=$pcapFileDir" >> ${ns3OutFile} 2>&1 & \
-  cd -
+  cd - || exit
 
 if [[ "$3" == "RC" ]]
 then

--- a/RC/make.sh
+++ b/RC/make.sh
@@ -143,9 +143,9 @@ cd $RD2C/PUSH
 cd NATIG
 cp -r integration $RD2C
 cp -r RC/code/run.sh ${RD2C}/integration/control
-cp -r RC/code/ns3-helics-grid-dnp3-4G.cc ${RD2C}/integration/control/ns3-helics-grid-dnp3-4G.cc
-cp -r RC/code/ns3-helics-grid-dnp3-5G.cc ${RD2C}/integration/control/ns3-helics-grid-dnp3-5G.cc
-cp -r RC/code/ns3-helics-grid-dnp3.cc ${RD2C}/integration/control/ns3-helics-grid-dnp3.cc 
+cp -r RC/code/ns3-helics-grid-dnp3-4G.cc ${RD2C}/integration/control/ns3-helics-grid-modbus-4G.cc
+cp -r RC/code/ns3-helics-grid-dnp3-5G.cc ${RD2C}/integration/control/ns3-helics-grid-modbus-5G.cc
+cp -r RC/code/ns3-helics-grid-dnp3.cc ${RD2C}/integration/control/ns3-helics-grid-modbus.cc
 cp -r RC/code/gridlabd/* ${RD2C}/gridlab-d/tape_file/
 cp -r RC/code/trigger.player ${RD2C}/integration/control/
 

--- a/integration/control/killall.sh
+++ b/integration/control/killall.sh
@@ -5,8 +5,8 @@ clear
 pkill -9 helics_broker
 pkill -9 gridlabd
 pkill -9 python
-pkill -9 ns3-helics-grid-dnp3
-pkill -9 ns3-helics-grid-dnp3-direct-analog
-pkill -9 ns3-helics-grid-dnp3-direct-binary
+pkill -9 ns3-helics-grid-modbus
+pkill -9 ns3-helics-grid-modbus-direct-analog
+pkill -9 ns3-helics-grid-modbus-direct-binary
 
 exit 0 

--- a/integration/control/run-123.sh
+++ b/integration/control/run-123.sh
@@ -29,14 +29,14 @@ fi
 #  cd -
 
 #cd ${ROOT_PATH} && \
-#helics_broker --federates=2 --port=5010 --config="${ROOT_PATH}/config/ns_config.json" --loglevel=${helicsLOGlevel} >> ${helicsOutFile} 2>&1 & \
-##helics_app tracer test.txt --config-file endpoints.txt --loglevel 7 --timedelta 1 >> tracer.txt 2>&1 & \
+#helics_broker --federates=2 --port=5010 --config="${ROOT_PATH}/config/ns_config.json" --loglevel=${helicsLOGlevel} >> ${helicsOutFile} 2>&1 &
+##helics_app tracer test.txt --config-file endpoints.txt --loglevel 7 --timedelta 1 >> tracer.txt 2>&1 &
 #cd -
 
 cd ${ROOT_PATH} && \
 helics_broker --slowresponding --federates=2 --port=6000 --loglevel=${helicsLOGlevel} >> ${helicsOutFile} 2>&1 & \
-#helics_app tracer test.txt --config-file endpoints.txt --loglevel 7 --timedelta 1 >> tracer.txt 2>&1 & \
-cd -
+#helics_app tracer test.txt --config-file endpoints.txt --loglevel 7 --timedelta 1 >> tracer.txt 2>&1 &
+cd - || exit
 
 # ===== starting GridLAB-D ===== 
 gldDir="${ROOT_PATH}"
@@ -49,7 +49,7 @@ then
 fi
 cd ${gldDir} && \
    gridlabd -D OUT_FOLDER=${OUT_DIR} ${gldModelFile} >> ${gldOutFile} 2>&1 & \
-   cd -
+   cd - || exit
 
 
 # ccDir="${ROOT_PATH}"
@@ -68,9 +68,9 @@ cd ${gldDir} && \
 # ===== setting up ns-3 configurations =====
 ns3Dir="/rd2c/ns-3-dev"
 ns3Scratch="${ns3Dir}/scratch"
-#modelName="ns3-helics-grid-dnp3-4G"
-#modelName="ns3-helics-grid-dnp3-5G" 
-modelName="ns3-helics-grid-dnp3"
+#modelName="ns3-helics-grid-modbus-4G"
+#modelName="ns3-helics-grid-modbus-5G"
+modelName="ns3-helics-grid-modbus"
 
 ns3Model="${ns3Scratch}/${modelName}"
 configDir="${ROOT_PATH}/config/"
@@ -90,8 +90,8 @@ if test -e $ns3OutFile
 cd ${ns3Dir} && \
 cp ${ROOT_PATH}/${modelName}.cc ${ns3Model}.cc && \
 sudo ./make.sh && \
-  #./waf --run "scratch/${modelName}" >> ${ns3OutFile} 2>&1 & \
+  #./waf --run "scratch/${modelName}" >> ${ns3OutFile} 2>&1 &
   mpirun -np 1 ./waf --run "scratch/${modelName} --helicsConfig=${helicsConfig} --microGridConfig=${microGridConfig} --topologyConfig=${topologyConfig} --pointFileDir=${configDir} --pcapFileDir=$pcapFileDir" >> ${ns3OutFile} 2>&1 & \
-  cd -
+  cd - || exit
 
 exit 0

--- a/integration/control/run-direct-analog.sh
+++ b/integration/control/run-direct-analog.sh
@@ -22,8 +22,8 @@ fi
 
 cd ${ROOT_PATH} && \
   helics_broker --federates=2 --loglevel=${helicsLOGlevel} >> ${helicsOutFile} 2>&1 & \
-  #helics_app tracer test.txt --config-file endpoints.txt --loglevel 7 --timedelta 1 >> tracer.txt 2>&1 & \
-  cd -
+  #helics_app tracer test.txt --config-file endpoints.txt --loglevel 7 --timedelta 1 >> tracer.txt 2>&1 &
+  cd - || exit
 
 # ===== starting GridLAB-D ===== 
 gldDir="${ROOT_PATH}"
@@ -36,7 +36,7 @@ then
 fi
 cd ${gldDir} && \
    gridlabd -D OUT_FOLDER=${OUT_DIR} ${gldModelFile} >> ${gldOutFile} 2>&1 & \
-   cd -
+   cd - || exit
 
 
 # ccDir="${ROOT_PATH}"
@@ -55,7 +55,7 @@ cd ${gldDir} && \
 # ===== setting up ns-3 configurations =====
 ns3Dir="/rd2c/ns-3-dev"
 ns3Scratch="${ns3Dir}/scratch"
-modelName="ns3-helics-grid-dnp3-direct-analog"
+modelName="ns3-helics-grid-modbus-direct-analog"
 ns3Model="${ns3Scratch}/${modelName}"
 configDir="${ROOT_PATH}/direct-analog-config/"
 helicsConfig="${configDir}/ns_config.json"
@@ -72,6 +72,6 @@ if test -e $ns3OutFile
 cd ${ns3Dir} && \
 cp ${ROOT_PATH}/${modelName}.cc ${ns3Model}.cc && \
   ./waf --run "scratch/${modelName} --helicsConfig=${helicsConfig} --microGridConfig=${microGridConfig} --pointFileDir=${configDir} --pcapFileDir=$pcapFileDir" >> ${ns3OutFile} 2>&1 & \
-  cd -
+  cd - || exit
 
 exit 0

--- a/integration/control/run-direct-binary.sh
+++ b/integration/control/run-direct-binary.sh
@@ -22,8 +22,8 @@ fi
 
 cd ${ROOT_PATH} && \
   helics_broker --federates=2 --loglevel=${helicsLOGlevel} >> ${helicsOutFile} 2>&1 & \
-  #helics_app tracer test.txt --config-file endpoints.txt --loglevel 7 --timedelta 1 >> tracer.txt 2>&1 & \
-  cd -
+  #helics_app tracer test.txt --config-file endpoints.txt --loglevel 7 --timedelta 1 >> tracer.txt 2>&1 &
+  cd - || exit
 
 # ===== starting GridLAB-D ===== 
 gldDir="${ROOT_PATH}"
@@ -36,7 +36,7 @@ then
 fi
 cd ${gldDir} && \
    gridlabd -D OUT_FOLDER=${OUT_DIR} ${gldModelFile} >> ${gldOutFile} 2>&1 & \
-   cd -
+   cd - || exit
 
 
 # ccDir="${ROOT_PATH}"
@@ -55,7 +55,7 @@ cd ${gldDir} && \
 # ===== setting up ns-3 configurations =====
 ns3Dir="/rd2c/ns-3-dev"
 ns3Scratch="${ns3Dir}/scratch"
-modelName="ns3-helics-grid-dnp3-direct-binary"
+modelName="ns3-helics-grid-modbus-direct-binary"
 ns3Model="${ns3Scratch}/${modelName}"
 configDir="${ROOT_PATH}/direct-binary-config/"
 helicsConfig="${configDir}/ns_config.json"
@@ -72,6 +72,6 @@ if test -e $ns3OutFile
 cd ${ns3Dir} && \
 cp ${ROOT_PATH}/${modelName}.cc ${ns3Model}.cc && \
   ./waf --run "scratch/${modelName} --helicsConfig=${helicsConfig} --microGridConfig=${microGridConfig} --pointFileDir=${configDir} --pcapFileDir=$pcapFileDir" >> ${ns3OutFile} 2>&1 & \
-  cd -
+  cd - || exit
 
 exit 0

--- a/integration/control/run.sh
+++ b/integration/control/run.sh
@@ -21,10 +21,10 @@ ROOT_PATH="${PWD}" # "/rd2c/integration/control"
 OUT_DIR="${ROOT_PATH}/output"
 
 
-if test ! -d ${OUT_DIR}
+if test ! -d "${OUT_DIR}"
 then
   echo "==== Simulation output folder does not exist yet. Creating ... ===="
-  mkdir ${OUT_DIR}
+  mkdir "${OUT_DIR}"
 else
   echo "==== Simulation output folder already exists. ===="
 fi
@@ -32,10 +32,10 @@ fi
 # ===== starting HELICS broker =====
 helicsLOGlevel=1
 helicsOutFile="${OUT_DIR}/helics_broker.log"
-if test -e $helicsOutFile
+if test -e "$helicsOutFile"
 then
   echo "$helicsOutFile exists. Deleting..."
-  rm $helicsOutFile
+  rm "$helicsOutFile"
 fi
 
 if [[ "$5" == "conf" ]]
@@ -47,28 +47,28 @@ if [[ "$2" == "4G" ]]
 then
 if [[ "$5" == "conf" ]]
 then
-    cp -r ${NATIG_SRC}/RC/code/4G-conf-${4}/*.json config/
-    cp -r ${NATIG_SRC}/RC/code/4G-conf-${4}/*.glm .
+    cp -r "${NATIG_SRC}/RC/code/4G-conf-${4}"/*.json config/
+    cp -r "${NATIG_SRC}/RC/code/4G-conf-${4}"/*.glm .
 fi
-modelName="ns3-helics-grid-dnp3-4G"
+modelName="ns3-helics-grid-modbus-4G"
 fi
 if [[ "$2" == "5G" ]]
 then
 if [[ "$5" == "conf" ]]
 then
-    cp -r ${NATIG_SRC}/RC/code/5G-conf-${4}/*.json config/
-    cp -r ${NATIG_SRC}/RC/code/5G-conf-${4}/*.glm .
+    cp -r "${NATIG_SRC}/RC/code/5G-conf-${4}"/*.json config/
+    cp -r "${NATIG_SRC}/RC/code/5G-conf-${4}"/*.glm .
 fi
-modelName="ns3-helics-grid-dnp3-5G"
+modelName="ns3-helics-grid-modbus-5G"
 fi
 if [[ "$2" == "3G" ]]
 then
 if [[ "$5" == "conf" ]]
 then
-    cp -r ${NATIG_SRC}/RC/code/3G-conf-${4}/*.json config/
-    cp -r ${NATIG_SRC}/RC/code/3G-conf-${4}/*.glm .
+    cp -r "${NATIG_SRC}/RC/code/3G-conf-${4}"/*.json config/
+    cp -r "${NATIG_SRC}/RC/code/3G-conf-${4}"/*.glm .
 fi
-modelName="ns3-helics-grid-dnp3"
+modelName="ns3-helics-grid-modbus"
 fi
 
 #sbatch run-helics.sh ${helicsLOGlevel} ${helicsOutFile}

--- a/integration/control/run_ns3_only.sh
+++ b/integration/control/run_ns3_only.sh
@@ -18,10 +18,10 @@ export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
 ROOT_PATH="${PWD}" # "/rd2c/integration/control"
 OUT_DIR="${ROOT_PATH}/output"
-if test ! -d ${OUT_DIR}
+if test ! -d "${OUT_DIR}"
 then
   echo "==== Simulation output folder does not exist yet. Creating ... ===="
-  mkdir ${OUT_DIR}
+  mkdir "${OUT_DIR}"
 else
   echo "==== Simulation output folder already exists. ===="
 fi
@@ -29,30 +29,30 @@ fi
 # ===== starting HELICS broker =====
 helicsLOGlevel=1
 helicsOutFile="${OUT_DIR}/helics_broker.log"
-if test -e $helicsOutFile
+if test -e "$helicsOutFile"
 then
   echo "$helicsOutFile exists. Deleting..."
-  rm $helicsOutFile
+  rm "$helicsOutFile"
 fi
 
 
 if [[ "$2" == "4G" ]]
 then
-cp -r ${NATIG_SRC}/RC/code/4G-conf-${4}/*.json config/
-cp -r ${NATIG_SRC}/RC/code/4G-conf-${4}/*.glm .
-modelName="ns3-helics-grid-dnp3-4G"
+cp -r "${NATIG_SRC}/RC/code/4G-conf-${4}"/*.json config/
+cp -r "${NATIG_SRC}/RC/code/4G-conf-${4}"/*.glm .
+modelName="ns3-helics-grid-modbus-4G"
 fi
 if [[ "$2" == "5G" ]]
 then
-cp -r ${NATIG_SRC}/RC/code/5G-conf-${4}/*.json config/
-cp -r ${NATIG_SRC}/RC/code/5G-conf-${4}/*.glm .
-modelName="ns3-helics-grid-dnp3-5G"
+cp -r "${NATIG_SRC}/RC/code/5G-conf-${4}"/*.json config/
+cp -r "${NATIG_SRC}/RC/code/5G-conf-${4}"/*.glm .
+modelName="ns3-helics-grid-modbus-5G"
 fi
 if [[ "$2" == "3G" ]]
 then
-cp -r ${NATIG_SRC}/RC/code/3G-conf-${4}/*.json config/
-cp -r ${NATIG_SRC}/RC/code/3G-conf-${4}/*.glm .
-modelName="ns3-helics-grid-dnp3"
+cp -r "${NATIG_SRC}/RC/code/3G-conf-${4}"/*.json config/
+cp -r "${NATIG_SRC}/RC/code/3G-conf-${4}"/*.glm .
+modelName="ns3-helics-grid-modbus"
 fi
 
 #sbatch run-helics.sh ${helicsLOGlevel} ${helicsOutFile}
@@ -61,7 +61,7 @@ v2=$( grep 'brokerPort' ${PWD}/config/gridlabd_config.json | sed -r 's/^[^:]*:(.
 cd ${ROOT_PATH} && \
 #helics_broker --federates=2 --port=$v2 --loglevel=${helicsLOGlevel} >> ${helicsOutFile} 2>&1 & \
  #helics_app tracer test.txt --config-file endpoints.txt --loglevel 7 --timedelta 1 >> tracer.txt 2>&1 & \
-cd -
+cd - || exit
 
 # ===== starting GridLAB-D ===== 
 gldDir="${ROOT_PATH}"
@@ -82,7 +82,7 @@ fi
 #sbatch run-gridlabd.sh ${OUT_DIR} ${gldModelFile} ${gldOutFile}
 cd ${gldDir} && \
 #gridlabd -D OUT_FOLDER=${OUT_DIR} ${gldModelFile} >> ${gldOutFile} 2>&1 & \
-   cd -
+   cd - || exit
 
 
 # ccDir="${ROOT_PATH}"
@@ -124,7 +124,7 @@ cd ${ns3Dir} && \
 cp ${ROOT_PATH}/${modelName}.cc ${ns3Model}.cc && \
 ./make.sh "$1" && \
   ./waf --run "scratch/${modelName} --helicsConfig=${helicsConfig} --microGridConfig=${microGridConfig} --topologyConfig=${topologyConfig} --pointFileDir=${configDir} --pcapFileDir=$pcapFileDir" >> ${ns3OutFile} 2>&1 & \
-  cd -
+  cd - || exit
 
 if [[ "$3" == "RC" ]]
 then

--- a/update_workstation.sh
+++ b/update_workstation.sh
@@ -27,9 +27,9 @@ if [ -d "${RD2C}/integration" ]; then
 fi
 cp -r integration ${RD2C}
 cp -r RC/code/run.sh ${RD2C}/integration/control 
-cp -r RC/code/ns3-helics-grid-dnp3-4G-Docker.cc ${RD2C}/integration/control/ns3-helics-grid-dnp3-4G.cc  
-cp -r RC/code/ns3-helics-grid-dnp3-5G-Docker.cc ${RD2C}/integration/control/ns3-helics-grid-dnp3-5G.cc 
-cp -r RC/code/ns3-helics-grid-dnp3-Docker.cc ${RD2C}/integration/control/ns3-helics-grid-dnp3.cc
+cp -r RC/code/ns3-helics-grid-dnp3-4G-Docker.cc ${RD2C}/integration/control/ns3-helics-grid-modbus-4G.cc
+cp -r RC/code/ns3-helics-grid-dnp3-5G-Docker.cc ${RD2C}/integration/control/ns3-helics-grid-modbus-5G.cc
+cp -r RC/code/ns3-helics-grid-dnp3-Docker.cc ${RD2C}/integration/control/ns3-helics-grid-modbus.cc
 rm -rf ${RD2C}/ns-3-dev/src/dnp3
 mkdir -p ${RD2C}/ns-3-dev/src/dnp3
 cp -r RC/code/dnp3/crypto ${RD2C}/ns-3-dev/src/dnp3  


### PR DESCRIPTION
## Summary
- switch ns3 model names from `*-dnp3` to `*-modbus`
- update helper scripts copying and killing ns3 processes
- run `shellcheck` on updated scripts and address easy warnings

## Testing
- `shellcheck integration/control/run-direct-binary.sh integration/control/run-direct-analog.sh integration/control/run.sh integration/control/run_ns3_only.sh integration/control/run-123.sh integration/control/killall.sh RC/code/run.sh RC/code/pythonFederate/tutorial.sh RC/make.sh update_workstation.sh`

------
https://chatgpt.com/codex/tasks/task_e_685061f4d7ac832f9f2c2a2cff67ece5