### PR TITLE
Remove DNP3 code from Modbus example

### DIFF
--- a/RC/code/ns3-helics-grid-modbus.cc
+++ b/RC/code/ns3-helics-grid-modbus.cc
@@ -522,7 +522,6 @@ main (int argc, char *argv[])
   {
     //LogComponentEnable ("IntagrationExample", LOG_LEVEL_INFO);
     // LogComponentEnable ("HelicsSimulatorImpl", LOG_LEVEL_LOGIC);
-    //LogComponentEnable ("Dnp3ApplicationNew", LOG_LEVEL_INFO);
     // LogComponentEnable ("HelicsApplication", LOG_LEVEL_LOGIC);
     //LogComponentEnable ("Names", LOG_LEVEL_LOGIC);
   }
@@ -829,17 +828,13 @@ main (int argc, char *argv[])
   // Create Modbus master/slave applications
   ApplicationContainer modbusMasterApp, modbusSlaveApp;
 
-  uint16_t port = 20000;
   uint16_t master_port = 40000;
-  ApplicationContainer dnpOutstationApp, dnpMasterApp;
   //Ptr<Node> hubNode = star.GetHub ();
-  std::vector<uint16_t> mimPort;
   //changing the parameters of the nodes in the network
   Simulator::Schedule (Seconds (3.2), &updatePower); 
 
   for (i = 0;i < configObject["microgrid"].size();i++)
   {
-    mimPort.push_back(master_port);
     auto ep_name = configObject["microgrid"][i]["name"].asString();
     std::cout << "Microgrid network node: " << ep_name << " " << Microgrid.GetN() << " " << configObject["microgrid"][i].size() << " " << i << std::endl;
     Ptr<Node> tempnode1 = Microgrid.Get(i); //star.GetSpokeNode (i);
@@ -868,43 +863,6 @@ main (int argc, char *argv[])
     }
     std::cout << ep_name << std::endl;
     interface[i] = i+1;
-    Dnp3ApplicationHelperNew dnp3Master ("ns3::UdpSocketFactory", InetSocketAddress (hubNode.Get(0)->GetObject<Ipv4>()->GetAddress(ID,0).GetLocal(), master_port));  //star.GetHubIpv4Address(i), master_port));
-
-    dnp3Master.SetAttribute("LocalPort", UintegerValue(master_port));
-    dnp3Master.SetAttribute("RemoteAddress", AddressValue(tempnode1->GetObject<Ipv4>()->GetAddress(1,0).GetLocal()));//star.GetSpokeIpv4Address (i)));
-    dnp3Master.SetAttribute("RemotePort", UintegerValue(port));
-    dnp3Master.SetAttribute("JitterMinNs", DoubleValue (std::stoi(topologyConfigObject["Channel"][0]["jitterMin"].asString())));
-    dnp3Master.SetAttribute("JitterMaxNs", DoubleValue (std::stoi(topologyConfigObject["Channel"][0]["jitterMax"].asString())));
-    dnp3Master.SetAttribute("isMaster", BooleanValue (true));
-    dnp3Master.SetAttribute("Name", StringValue (cc_name+ep_name)); //"_SS_"+std::to_string(i+1)));
-    dnp3Master.SetAttribute("PointsFilename", StringValue (pointFileDir+"/points_"+ep_name+".csv")); //pointFileDir+"/points_SS_"+std::to_string(i+1)+".csv"));
-    dnp3Master.SetAttribute("MasterDeviceAddress", UintegerValue(1));
-    dnp3Master.SetAttribute("StationDeviceAddress", UintegerValue(i+2));
-    dnp3Master.SetAttribute("IntegrityPollInterval", UintegerValue(10));
-    dnp3Master.SetAttribute("EnableTCP", BooleanValue (false));
-  
-    Ptr<Dnp3ApplicationNew> master = dnp3Master.Install (hubNode.Get(0), std::string(cc_name+ep_name)); //"_SS_"+std::to_string(i+1)));
-    dnpMasterApp.Add(master);
-
-    Dnp3ApplicationHelperNew dnp3Outstation ("ns3::UdpSocketFactory", InetSocketAddress (tempnode1->GetObject<Ipv4>()->GetAddress(1,0).GetLocal(), port)); //star.GetSpokeIpv4Address (i), port));
-    dnp3Outstation.SetAttribute("LocalPort", UintegerValue(port));
-    dnp3Outstation.SetAttribute("RemoteAddress", AddressValue(hubNode.Get(0)->GetObject<Ipv4>()->GetAddress(ID,0).GetLocal())); //star.GetHubIpv4Address(i)));
-    dnp3Outstation.SetAttribute("RemotePort", UintegerValue(master_port));
-    dnp3Outstation.SetAttribute("isMaster", BooleanValue (false));
-    dnp3Outstation.SetAttribute("Name", StringValue (ep_name)); //"SS_"+std::to_string(i+1)));
-    dnp3Outstation.SetAttribute("PointsFilename", StringValue (pointFileDir+"/points_"+ep_name+".csv")); //pointFileDir+"/points_SS_"+std::to_string(i+1)+".csv"));
-    dnp3Outstation.SetAttribute("MasterDeviceAddress", UintegerValue(1));
-    dnp3Outstation.SetAttribute("StationDeviceAddress", UintegerValue(i+2));
-    dnp3Outstation.SetAttribute("EnableTCP", BooleanValue (false));
-
-    Ptr<Dnp3ApplicationNew> slave = dnp3Outstation.Install (tempnode1, std::string(ep_name)); //"SS_"+std::to_string(i+1)));
-    dnpOutstationApp.Add(slave);
-    Simulator::Schedule(MilliSeconds(1005), &Dnp3ApplicationNew::periodic_poll, master, std::stoi(configObject["Simulation"][0]["PollReqFreq"].asString()));
-    // Simulator::Schedule(MilliSeconds(2005), &Dnp3HelicsApplication::send_control_binary, master,
-    //   Dnp3HelicsApplication::DIRECT, 0, ControlOutputRelayBlock::CLOSE);
-      // Dnp3HelicsApplication::DIRECT, 0, ControlOutputRelayBlock::TRIP);
-    Simulator::Schedule(MilliSeconds(3005), &Dnp3ApplicationNew::send_control_analog, master, 
-      Dnp3ApplicationNew::DIRECT, 0, -16);
     master_port += 1;
 
   }
@@ -932,109 +890,10 @@ main (int argc, char *argv[])
     std::cout << "Endpoint name: " << epName << std::endl;
  }
 
-  //Adding the MIM node
-  //Adding the Dnp3 application to man in the middle attack
-  //int MIM_ID = 0;
-  if (includeMIM == 1){
-    for (int x = 0; x < val.size(); x++){ //std::stoi(configObject["MIM"][0]["NumberAttackers"].asString()); x++){
-      /*int MIM_ID = std::stoi(val[x]) + 1; //x+1;
-      auto ep_name = configObject["MIM"][MIM_ID]["name"].asString();
-      Ptr<Node> tempnode = MIMNode.Get(MIM_ID-1); //star.GetSpokeNode (MIM_ID-1);
-      Names::Add(ep_name, tempnode);
-      std::string enamestring = ep_name;
-      Ptr<Ipv4> ip = Names::Find<Node>(enamestring)->GetObject<Ipv4>();
-      int ID = MIM_ID;
-      if (ring){
-          ID = 1;
-      }
-   
-      auto ep_name2 = configObject["microgrid"][MIM_ID-1]["name"].asString();
-      std::string IDx = "SS_";
-      if (std::string(ep_name2).find(IDx) != std::string::npos){
-	      ep_name2 = "SS_"+std::to_string(i+1);
-      }*/
-	    int MIM_ID = std::stoi(val[x]) + 1; //x+1;
-                  auto ep_name = configObject["MIM"][MIM_ID]["name"].asString();
-                  std::string ID2 = "SS_";
-                  auto ep_name2 = configObject["microgrid"][MIM_ID-1]["name"].asString();
-                  if (std::string(ep_name2).find(ID2) != std::string::npos){
-                      ep_name2 = "SS_"+std::to_string(MIM_ID);
-                  }
-		  //std::cout << "adding node " << ep_name2 << std::endl;
-                  Ptr<Node> tempnode = MIMNode.Get(MIM_ID-1); //star.GetSpokeNode (MIM_ID-1);
-                  Names::Add(ep_name, tempnode);
-                  std::string enamestring = ep_name;
-                  Ptr<Ipv4> ip = Names::Find<Node>(enamestring)->GetObject<Ipv4>();
-                  int ID = MIM_ID-1;
-
-
-      ip->GetObject<Ipv4L3ProtocolMIM> ()->victimAddr = hubNode.Get(0)->GetObject<Ipv4>()->GetAddress(ID,0).GetLocal(); //star.GetHubIpv4Address(MIM_ID-1);
-
-
-      //scenario 1, 2 and 3
-      Dnp3ApplicationHelperNew dnp3MIM1 ("ns3::UdpSocketFactory", InetSocketAddress (MIMNode.Get(MIM_ID-1)->GetObject<Ipv4>()->GetAddress(1,0).GetLocal(), port)); //star.GetSpokeIpv4Address(MIM_ID-1),port)); 
-      dnp3MIM1.SetAttribute("LocalPort", UintegerValue(port));
-      dnp3MIM1.SetAttribute("RemoteAddress", AddressValue(hubNode.Get(0)->GetObject<Ipv4>()->GetAddress(ID, 0).GetLocal())); //star.GetHubIpv4Address(MIM_ID-1)));
-      if(std::stoi(attack["MIM-"+std::to_string(MIM_ID)+"-attack_type"]) == 3 || std::stoi(attack["MIM-"+std::to_string(MIM_ID)+"-attack_type"]) == 4){
-          dnp3MIM1.SetAttribute("RemoteAddress2", AddressValue(Microgrid.Get(MIM_ID-1)->GetObject<Ipv4>()->GetAddress(1,0).GetLocal()));
-      }
-      dnp3MIM1.SetAttribute("RemotePort", UintegerValue(mimPort[MIM_ID-1]));
-
-      dnp3MIM1.SetAttribute ("PointsFilename", StringValue (pointFileDir+"/points_"+ep_name2+".csv"));
-      dnp3MIM1.SetAttribute("JitterMinNs", DoubleValue (500));
-      dnp3MIM1.SetAttribute("JitterMaxNs", DoubleValue (1000));
-      dnp3MIM1.SetAttribute("isMaster", BooleanValue (false));
-      dnp3MIM1.SetAttribute ("Name", StringValue (enamestring));
-      dnp3MIM1.SetAttribute("MasterDeviceAddress", UintegerValue(1));
-      dnp3MIM1.SetAttribute("StationDeviceAddress", UintegerValue(2));
-      dnp3MIM1.SetAttribute("IntegrityPollInterval", UintegerValue (10));
-      dnp3MIM1.SetAttribute("EnableTCP", BooleanValue (false));
-      dnp3MIM1.SetAttribute("AttackSelection", UintegerValue(std::stoi(attack["MIM-"+std::to_string(MIM_ID)+"-attack_type"])));
-
-      dnp3MIM1.SetAttribute("RealVal", StringValue(attack["MIM-"+std::to_string(MIM_ID)+"-real_val"]));
-
-      if (std::stoi(attack["MIM-"+std::to_string(MIM_ID)+"-attack_type"]) == 2 || std::stoi(attack["MIM-"+std::to_string(MIM_ID)+"-attack_type"]) == 4){
-         if(attack["MIM-"+std::to_string(MIM_ID)+"-scenario_id"] == "b"){
-            dnp3MIM1.SetAttribute("Value_attck_max", StringValue(attack["MIM-"+std::to_string(MIM_ID)+"-attack_val"]));
-            dnp3MIM1.SetAttribute("Value_attck_min", StringValue(attack["MIM-"+std::to_string(MIM_ID)+"-real_val"]));
-            dnp3MIM1.SetAttribute("NodeID", StringValue (attack["MIM-"+std::to_string(MIM_ID)+"-node_id"])); 
-            dnp3MIM1.SetAttribute("PointID", StringValue (attack["MIM-"+std::to_string(MIM_ID)+"-point_id"])); 
-         }
-         if(attack["MIM-"+std::to_string(MIM_ID)+"-scenario_id"] == "a"){
-            dnp3MIM1.SetAttribute("Value_attck", StringValue(attack["MIM-"+std::to_string(MIM_ID)+"-attack_val"]));
-            dnp3MIM1.SetAttribute("NodeID", StringValue (attack["MIM-"+std::to_string(MIM_ID)+"-node_id"])); 
-            dnp3MIM1.SetAttribute("PointID", StringValue (attack["MIM-"+std::to_string(MIM_ID)+"-point_id"])); 
-          }
-      }
-
-      if(std::stoi(attack["MIM-"+std::to_string(MIM_ID)+"-attack_type"]) == 3){
-         dnp3MIM1.SetAttribute("Value_attck", StringValue(attack["MIM-"+std::to_string(MIM_ID)+"-attack_val"]));
-         dnp3MIM1.SetAttribute("NodeID", StringValue (attack["MIM-"+std::to_string(MIM_ID)+"-node_id"])); 
-         dnp3MIM1.SetAttribute("PointID", StringValue (attack["MIM-"+std::to_string(MIM_ID)+"-point_id"])); 
-      }
-
-      dnp3MIM1.SetAttribute("AttackStartTime", StringValue(attack["MIM-"+std::to_string(MIM_ID)+"-Start"])); 
-      dnp3MIM1.SetAttribute("AttackEndTime", StringValue(attack["MIM-"+std::to_string(MIM_ID)+"-End"])); 
-      dnp3MIM1.SetAttribute("mitmFlag", BooleanValue(true));
-      Ptr<Dnp3ApplicationNew> mim = dnp3MIM1.Install (tempnode, enamestring);
-      ApplicationContainer dnpMIMApp(mim);
-      dnpMIMApp.Start (Seconds (start));
-      dnpMIMApp.Stop (simTime);
-
-    }
-  }
-
-
-
   modbusMasterApp.Start (Seconds (start));
   modbusMasterApp.Stop (simTime);
   modbusSlaveApp.Start (Seconds (start));
   modbusSlaveApp.Stop (simTime);
-
-  dnpMasterApp.Start (Seconds (start));
-  dnpMasterApp.Stop (simTime);
-  dnpOutstationApp.Start (Seconds (start));
-  dnpOutstationApp.Stop (simTime);
 
 
   std::cout << "Setting up Bots" << std::endl;


### PR DESCRIPTION
## Summary
- drop DNP3 helper usage in `ns3-helics-grid-modbus.cc`
- retain Modbus helpers and pcap tracing

## Testing
- `grep -n Dnp3 RC/code/ns3-helics-grid-modbus.cc`

------
https://chatgpt.com/codex/tasks/task_e_68506e4df514832fafeaf7049d0e61f5