### PR TITLE
Fix pair usage in modbus example

### DIFF
--- a/RC/code/ns3-helics-grid-modbus.cc
+++ b/RC/code/ns3-helics-grid-modbus.cc
@@ -806,7 +806,7 @@ main (int argc, char *argv[])
 	 std::string my_str = configObject["MIM"][j][item].asString();
 	 my_str.erase(remove(my_str.begin(), my_str.end(), '"'), my_str.end());
 	 std::cout << "This is the keys value: " << ID << "  and the value is " << my_str << std::endl;
-         attack.insert(pair<std::string,std::string >(ID, my_str));
+        attack.insert(std::pair<std::string, std::string>(ID, my_str));
      }
 
   }


### PR DESCRIPTION
## Summary
- use `std::pair` for inserting into `attack`

## Testing
- `grep -n "pair<" -n RC/code/ns3-helics-grid-modbus.cc`

------
https://chatgpt.com/codex/tasks/task_e_6850a1cdc228832fb8f2e43d4f2c891c