### PR TITLE
Replace dnp3 filename with modbus

### DIFF
--- a/RC/make.sh
+++ b/RC/make.sh
@@ -145,7 +145,7 @@ cp -r integration $RD2C
 cp -r RC/code/run.sh ${RD2C}/integration/control
 cp -r RC/code/ns3-helics-grid-dnp3-4G.cc ${RD2C}/integration/control/ns3-helics-grid-modbus-4G.cc
 cp -r RC/code/ns3-helics-grid-dnp3-5G.cc ${RD2C}/integration/control/ns3-helics-grid-modbus-5G.cc
-cp -r RC/code/ns3-helics-grid-dnp3.cc ${RD2C}/integration/control/ns3-helics-grid-modbus.cc
+cp -r RC/code/ns3-helics-grid-modbus.cc "${RD2C}"/integration/control/ns3-helics-grid-modbus.cc
 cp -r RC/code/gridlabd/* ${RD2C}/gridlab-d/tape_file/
 cp -r RC/code/trigger.player ${RD2C}/integration/control/
 

--- a/integration/control/README.md
+++ b/integration/control/README.md
@@ -27,7 +27,7 @@ Simply, run `run.sh` bash script. This script will run `helics_broker`, `gridlab
 - `gridlabd_config.json`: Helics configuration file for microgrids run on GridLAB-D.
 - `killall.sh`: Kill processes run by `run.sh` bash script.
 - `ns_config.json`: Helics configuration file for NS3 nodes corresponding to `cc_config.json` and `gridlabd_config.json`.
-- `ns3-helics-grid-dnp3.cc`: A NS3 model file. The program need to load `grid.json` and `ns_config.json`.
+- `ns3-helics-grid-modbus.cc`: A NS3 model file. The program need to load `grid.json` and `ns_config.json`.
 - `run.sh`: Bash script file that run helics broker and three Helics federates: microgrids (GridLAB-D), filter (NS3), and control center (python).
 - `IEEE_123_Dynamic.glm`: Main GridLAB-D model file based on IEEE 123 test feeder. It includes other submodules: `IEEE_123_Diesels.glm`, `IEEE_123_Inverters_Mixed.glm`, and `IEEE_123_Recorders.glm`. The model needs climate file `WA-Yakima.tmy2` climate, player files `Gen2_Pref.player`, `Gen3_Pref.player`, `Gen4_Pref.player`.
 - `config_helper.py`: A python program that creates configuration files (`cc_config.json`, `grid.json`, `gridlabd_config.json`, `ns_config.json`) and point files (`points_mg1.csv`, `points_mg2.csv`, `points_mg3.csv`, `points_substation.csv`).

--- a/update_workstation.sh
+++ b/update_workstation.sh
@@ -29,7 +29,7 @@ cp -r integration ${RD2C}
 cp -r RC/code/run.sh ${RD2C}/integration/control 
 cp -r RC/code/ns3-helics-grid-dnp3-4G-Docker.cc ${RD2C}/integration/control/ns3-helics-grid-modbus-4G.cc
 cp -r RC/code/ns3-helics-grid-dnp3-5G-Docker.cc ${RD2C}/integration/control/ns3-helics-grid-modbus-5G.cc
-cp -r RC/code/ns3-helics-grid-dnp3-Docker.cc ${RD2C}/integration/control/ns3-helics-grid-modbus.cc
+cp -r RC/code/ns3-helics-grid-modbus.cc "${RD2C}"/integration/control/ns3-helics-grid-modbus.cc
 rm -rf ${RD2C}/ns-3-dev/src/dnp3
 mkdir -p ${RD2C}/ns-3-dev/src/dnp3
 cp -r RC/code/dnp3/crypto ${RD2C}/ns-3-dev/src/dnp3  


### PR DESCRIPTION
## Summary
- update README for new ns-3 modbus example name
- copy modbus file in RC/make.sh
- copy modbus file in update_workstation.sh

## Testing
- `shellcheck RC/make.sh update_workstation.sh`
- `markdownlint integration/control/README.md`


------
https://chatgpt.com/codex/tasks/task_e_6850a637632c832f9b219b76e1480701